### PR TITLE
Feat: Make meeting day editable in Settings

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -24,6 +24,16 @@ import type {
   Topic,
 } from "../types/index";
 
+const DAYS_OF_WEEK = [
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+] as const;
+
 export function Settings(): React.ReactElement {
   const [settings, setSettings] = useState<GroupSettings | null>(null);
   const [savedSettings, setSavedSettings] = useState<GroupSettings | null>(
@@ -78,6 +88,7 @@ export function Settings(): React.ReactElement {
     try {
       const updated = await updateSettings({
         name: settings.name,
+        meeting_day: settings.meeting_day,
         format_rotation: settings.format_rotation,
       });
       setSettings(updated);
@@ -243,14 +254,24 @@ export function Settings(): React.ReactElement {
             onChange={(e) => setSettings({ ...settings, name: e.target.value })}
           />
         </label>
-        <p className="rd-meta">
-          Meeting Day:{" "}
-          {
-            ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"][
-              settings.meeting_day
-            ]
-          }
-        </p>
+        <label>
+          Meeting Day
+          <select
+            value={settings.meeting_day}
+            onChange={(e) =>
+              setSettings({
+                ...settings,
+                meeting_day: Number(e.target.value),
+              })
+            }
+          >
+            {DAYS_OF_WEEK.map((day, i) => (
+              <option key={day} value={i}>
+                {day}
+              </option>
+            ))}
+          </select>
+        </label>
         <p className="rd-meta">Start Date: {settings.start_date}</p>
       </section>
 

--- a/frontend/tests/Settings.test.tsx
+++ b/frontend/tests/Settings.test.tsx
@@ -148,6 +148,53 @@ describe("Settings", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders meeting day dropdown with correct initial value", async () => {
+    renderSettings();
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Sunday")).toBeInTheDocument();
+    });
+  });
+
+  it("shows sticky bar when meeting day is changed", async () => {
+    renderSettings();
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Sunday")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByDisplayValue("Sunday"), {
+      target: { value: "0" },
+    });
+
+    expect(screen.getByDisplayValue("Monday")).toBeInTheDocument();
+    expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
+  });
+
+  it("includes meeting_day in updateSettings call when saving", async () => {
+    (api.updateSettings as jest.Mock).mockResolvedValue({
+      ...mockSettings,
+      meeting_day: 1,
+    });
+    renderSettings();
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Sunday")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByDisplayValue("Sunday"), {
+      target: { value: "1" },
+    });
+
+    fireEvent.click(screen.getByText("Save Changes"));
+
+    await waitFor(() =>
+      expect(api.updateSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ meeting_day: 1 }),
+      ),
+    );
+  });
+
   it("shows toast on save error", async () => {
     (api.updateSettings as jest.Mock).mockRejectedValue(
       new Error("Save failed"),


### PR DESCRIPTION
## Summary
- Replace static meeting day text with a `<select>` dropdown (Monday–Sunday)
- Include `meeting_day` in the save payload sent to the backend
- Dirty state tracking automatically detects changes and shows sticky save bar
- Closes #26

## Test plan
- [x] `frontend/scripts/check-all.sh` — 4/4 green, 114 tests
- [ ] Change meeting day, verify sticky bar appears
- [ ] Save, verify backend receives new meeting_day
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)