### PR TITLE
Feat: Show group name in navbar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 /** Root application component with routing. */
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import {
   BrowserRouter,
   NavLink,
@@ -8,6 +8,7 @@ import {
   Route,
   Routes,
 } from "react-router-dom";
+import { getSettings } from "./api/index";
 import { ToastProvider } from "./contexts/ToastContext";
 import { useAuth } from "./hooks/useAuth";
 import { Landing } from "./pages/Landing";
@@ -20,12 +21,20 @@ function AuthenticatedApp({
 }: {
   onLogout: () => void;
 }): React.ReactElement {
+  const [groupName, setGroupName] = useState("RD Log");
+
+  useEffect(() => {
+    getSettings()
+      .then((settings) => setGroupName(settings.name))
+      .catch(() => {});
+  }, []);
+
   return (
     <>
       <nav className="container">
         <ul>
           <li>
-            <strong>RD Log</strong>
+            <strong>{groupName}</strong>
           </li>
         </ul>
         <ul>

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -1,30 +1,168 @@
 /** Smoke tests for App component rendering. */
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { App } from "../src/App";
+import type { GroupSettings } from "../src/types/index";
+
+// Mock useAuth to return authenticated state for navbar tests
+const mockUseAuth = jest.fn();
+jest.mock("../src/hooks/useAuth", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+// Mock page components to avoid API calls from child pages
+jest.mock("../src/pages/Landing", () => ({
+  Landing: () => <div data-testid="landing-page">Landing</div>,
+}));
+
+jest.mock("../src/pages/Log", () => ({
+  Log: () => <div data-testid="log-page">Log</div>,
+}));
+
+jest.mock("../src/pages/Settings", () => ({
+  Settings: () => <div data-testid="settings-page">Settings</div>,
+}));
+
+// Override BrowserRouter with MemoryRouter for test control
+jest.mock("react-router-dom", () => {
+  const actual = jest.requireActual("react-router-dom");
+  return {
+    ...actual,
+    BrowserRouter: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+  };
+});
+
+jest.mock("../src/api/index", () => ({
+  getSettings: jest.fn(),
+  isLoggedIn: jest.fn(() => false),
+  login: jest.fn(),
+  logout: jest.fn(),
+  register: jest.fn(),
+}));
+
+import * as api from "../src/api/index";
+
+const mockSettings: GroupSettings = {
+  name: "Test Group Name",
+  meeting_day: 6,
+  start_date: "2025-01-05",
+  meeting_time: "18:00:00",
+  format_rotation: ["Speaker", "Topic", "Book Study"],
+};
+
+const unauthState = {
+  user: null,
+  isAuthenticated: false,
+  error: null,
+  loading: false,
+  login: jest.fn(),
+  register: jest.fn(),
+  logout: jest.fn(),
+};
+
+const authState = {
+  user: { id: 1, username: "test", group_id: 1 },
+  isAuthenticated: true,
+  error: null,
+  loading: false,
+  login: jest.fn(),
+  register: jest.fn(),
+  logout: jest.fn(),
+};
 
 describe("App", () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     localStorage.clear();
+    mockUseAuth.mockReturnValue(unauthState);
   });
 
   it("renders login page when not authenticated", () => {
-    render(<App />);
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>,
+    );
     expect(screen.getByRole("heading", { name: "Log In" })).toBeInTheDocument();
   });
 
   it("shows username input field", () => {
-    render(<App />);
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>,
+    );
     expect(screen.getByLabelText("Username")).toBeInTheDocument();
   });
 
   it("shows password input field", () => {
-    render(<App />);
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>,
+    );
     expect(screen.getByLabelText("Password")).toBeInTheDocument();
   });
 
   it("shows register toggle button", () => {
-    render(<App />);
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>,
+    );
     expect(screen.getByText("Need an account? Register")).toBeInTheDocument();
+  });
+
+  describe("group name in navbar", () => {
+    it("displays group name from settings when authenticated", async () => {
+      mockUseAuth.mockReturnValue(authState);
+      (api.getSettings as jest.Mock).mockResolvedValue(mockSettings);
+
+      render(
+        <MemoryRouter>
+          <App />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Test Group Name")).toBeInTheDocument();
+      });
+    });
+
+    it("shows fallback RD Log while settings are loading", () => {
+      mockUseAuth.mockReturnValue(authState);
+      (api.getSettings as jest.Mock).mockReturnValue(new Promise(() => {}));
+
+      render(
+        <MemoryRouter>
+          <App />
+        </MemoryRouter>,
+      );
+
+      expect(screen.getByText("RD Log")).toBeInTheDocument();
+    });
+
+    it("keeps fallback RD Log when settings fetch fails", async () => {
+      mockUseAuth.mockReturnValue(authState);
+      (api.getSettings as jest.Mock).mockRejectedValue(
+        new Error("Network error"),
+      );
+
+      render(
+        <MemoryRouter>
+          <App />
+        </MemoryRouter>,
+      );
+
+      // Wait for the rejection to be handled
+      await waitFor(() => {
+        expect(api.getSettings).toHaveBeenCalled();
+      });
+
+      expect(screen.getByText("RD Log")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/tests/NavLink.test.tsx
+++ b/frontend/tests/NavLink.test.tsx
@@ -30,6 +30,15 @@ jest.mock("../src/pages/Settings", () => ({
   Settings: () => <div data-testid="settings-page">Settings</div>,
 }));
 
+// Mock API to handle getSettings call in AuthenticatedApp
+jest.mock("../src/api/index", () => ({
+  getSettings: jest.fn().mockResolvedValue({ name: "RD Log" }),
+  isLoggedIn: jest.fn(() => true),
+  login: jest.fn(),
+  logout: jest.fn(),
+  register: jest.fn(),
+}));
+
 // Override BrowserRouter with MemoryRouter for test control
 jest.mock("react-router-dom", () => {
   const actual = jest.requireActual("react-router-dom");


### PR DESCRIPTION
## Summary
- Fetch group settings on mount in `AuthenticatedApp` and display group name in navbar
- Falls back to "RD Log" while loading or on error
- Closes #31

## Test plan
- [x] `frontend/scripts/check-all.sh` — 4/4 green, 115 tests
- [ ] Verify navbar shows group name after login
- [ ] Verify "RD Log" fallback on network error
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)