### PR TITLE
Feat: Show deck state prominently with visual progress meter

### DIFF
--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -179,6 +179,25 @@ export function Landing(): React.ReactElement {
           <>
             {meeting.format_type === "Topic" && (
               <section>
+                <div className="rd-deck-meter">
+                  <div className="rd-deck-meter__label">
+                    {meeting.topics_remaining} of {meeting.topics_total} topics
+                    remain
+                  </div>
+                  <div className="rd-deck-meter__bar">
+                    <div
+                      className="rd-deck-meter__fill"
+                      role="progressbar"
+                      aria-valuenow={meeting.topics_remaining}
+                      aria-valuemin={0}
+                      aria-valuemax={meeting.topics_total}
+                      aria-label="Topics remaining in deck"
+                      style={{
+                        width: `${meeting.topics_total > 0 ? (meeting.topics_remaining / meeting.topics_total) * 100 : 0}%`,
+                      }}
+                    />
+                  </div>
+                </div>
                 {meeting.topic_name ? (
                   <>
                     <p>
@@ -206,10 +225,6 @@ export function Landing(): React.ReactElement {
                     Draw Topic
                   </button>
                 )}
-                <p className="rd-deck-status">
-                  {meeting.topics_remaining} of {meeting.topics_total} topics
-                  remain in deck
-                </p>
               </section>
             )}
 

--- a/frontend/src/styles/rd-theme.css
+++ b/frontend/src/styles/rd-theme.css
@@ -678,6 +678,31 @@ p[role="alert"] {
   font-size: var(--rd-font-size-sm);
 }
 
+/* Deck meter - visual progress bar for topic deck */
+.rd-deck-meter {
+  margin-bottom: var(--rd-space-sm);
+}
+
+.rd-deck-meter__label {
+  font-size: var(--rd-font-size-sm);
+  font-weight: 600;
+  margin-bottom: var(--rd-space-xs);
+}
+
+.rd-deck-meter__bar {
+  height: 8px;
+  background: var(--rd-teal-pale);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.rd-deck-meter__fill {
+  height: 100%;
+  background: var(--rd-teal);
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
 /* Speaker display with edit/remove actions */
 .rd-speaker-display {
   display: flex;

--- a/frontend/tests/Landing.test.tsx
+++ b/frontend/tests/Landing.test.tsx
@@ -177,15 +177,36 @@ describe("Landing", () => {
     });
   });
 
-  it("renders deck status for topic format", async () => {
+  it("renders deck meter for topic format", async () => {
     getUpcomingMeeting.mockResolvedValue(baseMeeting);
     renderLanding();
 
     await waitFor(() => {
-      expect(
-        screen.getByText("5 of 10 topics remain in deck"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("5 of 10 topics remain")).toBeInTheDocument();
     });
+    const progressbar = screen.getByRole("progressbar", {
+      name: "Topics remaining in deck",
+    });
+    expect(progressbar).toBeInTheDocument();
+    expect(progressbar.style.width).toBe("50%");
+  });
+
+  it("renders 0% width when topics_total is zero", async () => {
+    getUpcomingMeeting.mockResolvedValue({
+      ...baseMeeting,
+      topic_name: null,
+      topics_remaining: 0,
+      topics_total: 0,
+    });
+    renderLanding();
+
+    await waitFor(() => {
+      expect(screen.getByText("0 of 0 topics remain")).toBeInTheDocument();
+    });
+    const progressbar = screen.getByRole("progressbar", {
+      name: "Topics remaining in deck",
+    });
+    expect(progressbar.style.width).toBe("0%");
   });
 
   it("renders banners when present", async () => {
@@ -309,7 +330,9 @@ describe("Landing", () => {
         screen.queryByText("Meditation Practices"),
       ).not.toBeInTheDocument();
       expect(
-        screen.queryByText(/topics remain in deck/),
+        screen.queryByRole("progressbar", {
+          name: "Topics remaining in deck",
+        }),
       ).not.toBeInTheDocument();
     });
 


### PR DESCRIPTION
## Summary
- Move deck status above the Draw Topic button so it's visible before drawing
- Replace plain text with a visual progress meter (filled bar showing remaining/total)
- Handles zero-total edge case to avoid division by zero
- Closes #24

## Test plan
- [x] `frontend/scripts/check-all.sh` — 4/4 green, 112 tests
- [ ] Verify deck meter shows before and after drawing a topic
- [ ] Verify progress bar fill width reflects remaining/total ratio
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)