### PR TITLE
feat: add speaker name autocomplete from history

### DIFF
--- a/backend/app/routers/speakers.py
+++ b/backend/app/routers/speakers.py
@@ -13,6 +13,25 @@ from app.schemas import SpeakerSchedule, SpeakerScheduleCreate
 router = APIRouter(prefix="/speakers", tags=["speakers"])
 
 
+@router.get("/names", response_model=list[str])
+def get_speaker_names(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[str]:
+    """Get all unique speaker names from history."""
+    entries = (
+        db.query(MeetingLog.speaker_name)
+        .filter(
+            MeetingLog.group_id == current_user.group_id,
+            MeetingLog.speaker_name.isnot(None),
+            MeetingLog.speaker_name != "",
+        )
+        .distinct()
+        .all()
+    )
+    return sorted(name for (name,) in entries)
+
+
 @router.get("/schedule", response_model=list[SpeakerSchedule])
 def get_speaker_schedule(
     current_user: User = Depends(get_current_user),

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -488,6 +488,43 @@ class TestSpeakersEndpoints:
         )
         assert response.status_code == 200
 
+    def test_get_names_empty(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Get speaker names returns empty list when none scheduled."""
+        response = client.get("/speakers/names", headers=auth_headers)
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_get_names_returns_deduplicated_sorted(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Get speaker names returns deduplicated sorted list."""
+        # Schedule multiple speakers, some duplicates
+        client.post(
+            "/speakers/schedule",
+            json={"meeting_date": "2025-03-02", "speaker_name": "Zara"},
+            headers=auth_headers,
+        )
+        client.post(
+            "/speakers/schedule",
+            json={"meeting_date": "2025-03-09", "speaker_name": "Alice"},
+            headers=auth_headers,
+        )
+        client.post(
+            "/speakers/schedule",
+            json={"meeting_date": "2025-03-16", "speaker_name": "Zara"},
+            headers=auth_headers,
+        )
+        response = client.get("/speakers/names", headers=auth_headers)
+        assert response.status_code == 200
+        names = response.json()
+        assert names == ["Alice", "Zara"]
+
 
 class TestSettingsEndpoints:
     """Tests for settings endpoints."""

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -150,6 +150,10 @@ export async function deleteAssignment(assignmentId: number): Promise<void> {
 
 // --- Speakers ---
 
+export async function getSpeakerNames(): Promise<string[]> {
+  return api.get<string[]>("/speakers/names");
+}
+
 export async function getSpeakerSchedule(): Promise<SpeakerSchedule[]> {
   return api.get<SpeakerSchedule[]>("/speakers/schedule");
 }

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import {
   cancelMeeting,
   drawTopic,
+  getSpeakerNames,
   getUpcomingMeeting,
   getUpcomingMeetings,
   scheduleSpeaker,
@@ -22,6 +23,7 @@ export function Landing(): React.ReactElement {
   const [error, setError] = useState<string | null>(null);
   const [speakerInput, setSpeakerInput] = useState("");
   const [showSpeakerForm, setShowSpeakerForm] = useState(false);
+  const [speakerNames, setSpeakerNames] = useState<string[]>([]);
   const [isCancelling, setIsCancelling] = useState(false);
   const [attendanceInput, setAttendanceInput] = useState("");
   const [showAttendanceForm, setShowAttendanceForm] = useState(false);
@@ -44,6 +46,14 @@ export function Landing(): React.ReactElement {
   useEffect(() => {
     refresh().finally(() => setLoading(false));
   }, [refresh]);
+
+  useEffect(() => {
+    if (showSpeakerForm) {
+      getSpeakerNames()
+        .then(setSpeakerNames)
+        .catch(() => setSpeakerNames([]));
+    }
+  }, [showSpeakerForm]);
 
   const handleDrawTopic = useCallback(async () => {
     try {
@@ -266,6 +276,7 @@ export function Landing(): React.ReactElement {
                           placeholder="Speaker name"
                           value={speakerInput}
                           onChange={(e) => setSpeakerInput(e.target.value)}
+                          list="speaker-names"
                         />
                         <button type="submit">Save</button>
                         <button
@@ -317,6 +328,7 @@ export function Landing(): React.ReactElement {
                           placeholder="Speaker name"
                           value={speakerInput}
                           onChange={(e) => setSpeakerInput(e.target.value)}
+                          list="speaker-names"
                         />
                         <button type="submit">Schedule</button>
                         <button
@@ -434,6 +446,11 @@ export function Landing(): React.ReactElement {
           </ul>
         </section>
       )}
+      <datalist id="speaker-names">
+        {speakerNames.map((name) => (
+          <option key={name} value={name} />
+        ))}
+      </datalist>
     </main>
   );
 }

--- a/frontend/tests/Landing.test.tsx
+++ b/frontend/tests/Landing.test.tsx
@@ -9,6 +9,7 @@ import type { UpcomingMeeting } from "../src/types/index";
 jest.mock("../src/api/index", () => ({
   getUpcomingMeeting: jest.fn(),
   getUpcomingMeetings: jest.fn(),
+  getSpeakerNames: jest.fn(),
   drawTopic: jest.fn(),
   undoTopicDraw: jest.fn(),
   scheduleSpeaker: jest.fn(),
@@ -27,6 +28,7 @@ function renderLanding(): void {
 
 const getUpcomingMeeting = api.getUpcomingMeeting as jest.Mock;
 const getUpcomingMeetings = api.getUpcomingMeetings as jest.Mock;
+const getSpeakerNames = api.getSpeakerNames as jest.Mock;
 const drawTopic = api.drawTopic as jest.Mock;
 const undoTopicDraw = api.undoTopicDraw as jest.Mock;
 const cancelMeeting = api.cancelMeeting as jest.Mock;
@@ -98,6 +100,7 @@ describe("Landing", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     getUpcomingMeetings.mockResolvedValue(lookaheadMeetings);
+    getSpeakerNames.mockResolvedValue([]);
   });
 
   it("renders formatted meeting date", async () => {
@@ -650,6 +653,34 @@ describe("Landing", () => {
 
       await waitFor(() => {
         expect(unscheduleSpeaker).toHaveBeenCalledWith("2026-02-22");
+      });
+    });
+
+    it("renders datalist with speaker name options when form is shown", async () => {
+      getSpeakerNames.mockResolvedValue(["Alice", "Bob", "Zara"]);
+      getUpcomingMeeting.mockResolvedValue(speakerMeetingNoSpeaker);
+      renderLanding();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Schedule Speaker" }),
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Schedule Speaker" }));
+
+      await waitFor(() => {
+        expect(getSpeakerNames).toHaveBeenCalled();
+      });
+
+      await waitFor(() => {
+        const datalist = document.getElementById("speaker-names");
+        expect(datalist).toBeInTheDocument();
+        const options = datalist!.querySelectorAll("option");
+        expect(options).toHaveLength(3);
+        expect(options[0]).toHaveAttribute("value", "Alice");
+        expect(options[1]).toHaveAttribute("value", "Bob");
+        expect(options[2]).toHaveAttribute("value", "Zara");
       });
     });
 


### PR DESCRIPTION
## Summary
- Backend: added `GET /speakers/names` endpoint returning distinct speaker names from history
- Frontend: added `getSpeakerNames()` API function and `<datalist>` autocomplete on speaker input fields
- Speaker name suggestions populated from historical data

Closes #29

## Test plan
- [ ] Backend: 106 tests passing, 91.15% coverage
- [ ] Frontend: 135 tests passing, 4/4 checks green
- [ ] Verify autocomplete suggestions appear when typing speaker names
- [ ] Verify new names are suggested after being used

🤖 Generated with [Claude Code](https://claude.com/claude-code)