### PR TITLE
feat: tie reading assignments to specific meeting dates

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,6 +16,7 @@ from app.routers import settings as settings_router
 # Columns added after initial schema. Each entry is (table, column, type).
 _MIGRATIONS: list[tuple[str, str, str]] = [
     ("meeting_logs", "attendance_count", "INTEGER"),
+    ("reading_assignments", "meeting_date", "DATE"),
 ]
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -192,6 +192,7 @@ class ReadingAssignment(Base):
         nullable=False,
         default="[]",
     )
+    meeting_date: Mapped[date | None] = mapped_column(Date, nullable=True)
 
     group: Mapped["Group"] = relationship(
         back_populates="reading_assignments",

--- a/backend/app/routers/book.py
+++ b/backend/app/routers/book.py
@@ -92,6 +92,7 @@ def list_assignments(
                 "assignment_order": assignment.assignment_order,
                 "chapters": chapter_dicts,
                 "total_pages": total,
+                "meeting_date": assignment.meeting_date,
             }
         )
     return result

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -172,6 +172,7 @@ class ReadingAssignmentResponse(BaseModel):
     assignment_order: int
     chapters: list[BookChapterResponse]
     total_pages: int
+    meeting_date: date | None = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/services.py
+++ b/backend/app/services.py
@@ -255,6 +255,48 @@ def reshuffle_deck(db: Session, group: Group) -> int:
     return new_cycle
 
 
+# --- Book Study Date Projection ---
+
+
+def get_nth_book_study_date(
+    db: Session,
+    group: Group,
+    n: int,
+) -> date | None:
+    """Return the date of the Nth Book Study meeting (1-indexed).
+
+    Walks forward from the group's start_date, counting weeks whose
+    format is "Book Study" according to get_format_for_date, skipping
+    cancelled meetings.
+    """
+    if n < 1:
+        return None
+
+    current = get_next_meeting_date(group, after=group.start_date)
+    count = 0
+    # Safety cap to avoid infinite loops (10 years of weekly meetings).
+    max_iterations = 520
+    for _ in range(max_iterations):
+        fmt = get_format_for_date(db, group, current)
+        if fmt == "Book Study":
+            # Check if the meeting is cancelled
+            log_entry = (
+                db.query(MeetingLog)
+                .filter(
+                    MeetingLog.group_id == group.id,
+                    MeetingLog.meeting_date == current,
+                    MeetingLog.is_cancelled.is_(True),
+                )
+                .first()
+            )
+            if not log_entry:
+                count += 1
+                if count == n:
+                    return current
+        current += timedelta(days=7)
+    return None
+
+
 # --- Book Reading Plan Engine ---
 
 
@@ -369,6 +411,7 @@ def get_plan_status(db: Session, group: Group) -> dict:
                     "assignment_order": assignment.assignment_order,
                     "chapters": chapter_dicts,
                     "total_pages": total,
+                    "meeting_date": assignment.meeting_date,
                 }
             )
 
@@ -420,6 +463,11 @@ def finalize_current_assignment(db: Session, group: Group) -> dict | None:
     if not chapter_ids:
         return None
 
+    # Compute the meeting date for this assignment: it's the Nth Book Study
+    # date, where N = this assignment's order.
+    meeting_date = get_nth_book_study_date(db, group, draft.assignment_order)
+    draft.meeting_date = meeting_date
+
     chapter_dicts = _chapters_for_ids(db, chapter_ids)
     total = sum(int(c["page_count"]) for c in chapter_dicts)
 
@@ -436,6 +484,7 @@ def finalize_current_assignment(db: Session, group: Group) -> dict | None:
         "assignment_order": draft.assignment_order,
         "chapters": chapter_dicts,
         "total_pages": total,
+        "meeting_date": meeting_date,
     }
 
 
@@ -480,6 +529,7 @@ def update_assignment_chapters(
         "assignment_order": assignment.assignment_order,
         "chapters": chapter_dicts,
         "total_pages": total,
+        "meeting_date": assignment.meeting_date,
     }
 
 

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -23,6 +23,7 @@ from app.services import (
     get_deck_stats,
     get_format_for_date,
     get_next_meeting_date,
+    get_nth_book_study_date,
     get_plan_status,
     get_rotation_for_group,
     get_upcoming_meeting_data,
@@ -447,6 +448,80 @@ class TestBookReadingPlan:
         status = get_plan_status(db_session, group)
         assert status["assigned_chapters"] == 2
         assert status["assigned_pages"] == 4
+
+
+class TestBookStudyDateProjection:
+    """Tests for computing Book Study meeting dates."""
+
+    def test_first_book_study_date(self, db_session: Session) -> None:
+        group = _create_group(db_session, start=date(2025, 1, 5))
+        # Rotation: Speaker, Topic, Book Study, Topic, Book Study
+        # Week-of-month: 1st Sun=Speaker, 2nd=Topic, 3rd=Book Study
+        result = get_nth_book_study_date(db_session, group, 1)
+        assert result == date(2025, 1, 19)  # 3rd Sunday of Jan 2025
+
+    def test_second_book_study_date(self, db_session: Session) -> None:
+        group = _create_group(db_session, start=date(2025, 1, 5))
+        # Week-of-month position 2 = Book Study. Jan 19 is first, Feb 16 is second.
+        result = get_nth_book_study_date(db_session, group, 2)
+        assert result == date(2025, 2, 16)  # 3rd Sunday of Feb 2025
+
+    def test_invalid_n_returns_none(self, db_session: Session) -> None:
+        group = _create_group(db_session, start=date(2025, 1, 5))
+        assert get_nth_book_study_date(db_session, group, 0) is None
+        assert get_nth_book_study_date(db_session, group, -1) is None
+
+    def test_skips_cancelled_book_study(self, db_session: Session) -> None:
+        group = _create_group(db_session, start=date(2025, 1, 5))
+        # Cancel the first Book Study (3rd Sunday = Jan 19)
+        db_session.add(
+            MeetingLog(
+                group_id=group.id,
+                meeting_date=date(2025, 1, 19),
+                format_type="Book Study",
+                is_cancelled=True,
+            )
+        )
+        db_session.flush()
+        # The 1st non-cancelled Book Study should skip Jan 19
+        result = get_nth_book_study_date(db_session, group, 1)
+        assert result != date(2025, 1, 19)
+        assert result is not None
+
+    def test_finalize_sets_meeting_date(self, db_session: Session) -> None:
+        group = _create_group(db_session, start=date(2025, 1, 5))
+        _create_chapters(db_session, group)
+        add_chapter_to_current_assignment(db_session, group)
+        result = finalize_current_assignment(db_session, group)
+        assert result is not None
+        assert result["meeting_date"] == date(2025, 1, 19)
+
+    def test_finalize_second_assignment_gets_second_date(
+        self, db_session: Session
+    ) -> None:
+        group = _create_group(db_session, start=date(2025, 1, 5))
+        _create_chapters(db_session, group)
+        # Finalize first assignment
+        add_chapter_to_current_assignment(db_session, group)
+        result1 = finalize_current_assignment(db_session, group)
+        assert result1 is not None
+
+        # Finalize second assignment
+        add_chapter_to_current_assignment(db_session, group)
+        result2 = finalize_current_assignment(db_session, group)
+        assert result2 is not None
+        assert result2["meeting_date"] is not None
+        # Second date should be after first
+        assert result2["meeting_date"] > result1["meeting_date"]
+
+    def test_plan_status_includes_meeting_date(self, db_session: Session) -> None:
+        group = _create_group(db_session, start=date(2025, 1, 5))
+        _create_chapters(db_session, group)
+        add_chapter_to_current_assignment(db_session, group)
+        finalize_current_assignment(db_session, group)
+        status = get_plan_status(db_session, group)
+        assert len(status["completed_assignments"]) == 1
+        assert status["completed_assignments"][0]["meeting_date"] == date(2025, 1, 19)
 
 
 class TestAssignmentEditing:

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -23,7 +23,7 @@ import type {
   ReadingPlanStatus,
   Topic,
 } from "../types/index";
-import { formatLogDate } from "../utils/dates";
+import { formatLogDate, formatShortDate } from "../utils/dates";
 
 const DAYS_OF_WEEK = [
   "Monday",
@@ -554,6 +554,12 @@ export function Settings(): React.ReactElement {
                         <span>
                           {a.chapters.map((c) => c.title).join(", ")} (
                           {a.total_pages} pages)
+                          {a.meeting_date && (
+                            <span className="rd-assignment-item__date">
+                              {" "}
+                              &mdash; {formatShortDate(a.meeting_date)}
+                            </span>
+                          )}
                         </span>
                         <span className="rd-assignment-item__actions">
                           <button

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -95,6 +95,7 @@ export interface ReadingAssignment {
   assignment_order: number;
   chapters: BookChapter[];
   total_pages: number;
+  meeting_date: string | null;
 }
 
 export interface AssignmentUpdate {

--- a/frontend/src/utils/dates.ts
+++ b/frontend/src/utils/dates.ts
@@ -29,6 +29,19 @@ export function formatLogDate(isoDate: string): string {
 }
 
 /**
+ * Format an ISO date string as "Mar 15".
+ * Used for compact date display such as reading assignment dates.
+ */
+export function formatShortDate(isoDate: string): string {
+  const [year, month, day] = isoDate.split("-").map(Number);
+  const date = new Date(year, month - 1, day);
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/**
  * Format a time string (HH:MM or HH:MM:SS) as "6:00 PM".
  * Returns null if the input is null or empty.
  */

--- a/frontend/tests/Settings.test.tsx
+++ b/frontend/tests/Settings.test.tsx
@@ -384,6 +384,76 @@ describe("Settings", () => {
     expect(api.getReadingPlan).toHaveBeenCalledTimes(2); // initial + after add
   });
 
+  it("displays meeting date next to finalized assignment", async () => {
+    const planWithAssignment: ReadingPlanStatus = {
+      ...mockPlan,
+      total_chapters: 3,
+      assigned_chapters: 1,
+      total_pages: 6,
+      assigned_pages: 1,
+      completed_assignments: [
+        {
+          id: 1,
+          assignment_order: 1,
+          chapters: [
+            {
+              id: 1,
+              order: 1,
+              start_page: "1",
+              end_page: "10",
+              title: "Preface",
+              page_count: 9,
+            },
+          ],
+          total_pages: 9,
+          meeting_date: "2025-03-15",
+        },
+      ],
+    };
+    (api.getReadingPlan as jest.Mock).mockResolvedValue(planWithAssignment);
+    renderSettings();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Mar 15/)).toBeInTheDocument();
+    });
+  });
+
+  it("does not show date when assignment has no meeting_date", async () => {
+    const planWithAssignment: ReadingPlanStatus = {
+      ...mockPlan,
+      total_chapters: 3,
+      assigned_chapters: 1,
+      total_pages: 6,
+      assigned_pages: 1,
+      completed_assignments: [
+        {
+          id: 1,
+          assignment_order: 1,
+          chapters: [
+            {
+              id: 1,
+              order: 1,
+              start_page: "1",
+              end_page: "10",
+              title: "Preface",
+              page_count: 9,
+            },
+          ],
+          total_pages: 9,
+          meeting_date: null,
+        },
+      ],
+    };
+    (api.getReadingPlan as jest.Mock).mockResolvedValue(planWithAssignment);
+    renderSettings();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Preface/)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/\u2014\s+\w{3}\s+\d/)).not.toBeInTheDocument();
+  });
+
   it("does not display last-used text for topics without a date", async () => {
     const topicsWithoutDates: Topic[] = [
       {


### PR DESCRIPTION
## Summary
- Backend: added `meeting_date` column to `ReadingAssignment` model with migration, added `get_nth_book_study_date()` to project Book Study dates (skipping cancelled meetings), auto-computes date on finalize
- Frontend: shows projected meeting date (e.g. "Mar 15") next to each finalized assignment in Settings
- Added `formatShortDate()` utility for compact date display

Closes #30

## Test plan
- [ ] Backend: 111 tests passing, 91.18% coverage
- [ ] Frontend: 136 tests passing, 4/4 checks green
- [ ] Verify finalized assignments show projected meeting dates
- [ ] Verify cancelled meetings are skipped in date projection

🤖 Generated with [Claude Code](https://claude.com/claude-code)