### PR TITLE
feat: add section navigation to Settings page

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -270,7 +270,22 @@ export function Settings(): React.ReactElement {
     <main className="rd-settings">
       <h1>Settings</h1>
 
-      <section>
+      <nav className="rd-section-nav" aria-label="Section navigation">
+        <a className="rd-section-nav__link" href="#meeting">
+          Meeting
+        </a>
+        <a className="rd-section-nav__link" href="#rotation">
+          Rotation
+        </a>
+        <a className="rd-section-nav__link" href="#topics">
+          Topics
+        </a>
+        <a className="rd-section-nav__link" href="#reading-plan">
+          Reading Plan
+        </a>
+      </nav>
+
+      <section id="meeting">
         <h2>Meeting Info</h2>
         <label>
           Group Name
@@ -301,7 +316,7 @@ export function Settings(): React.ReactElement {
         <p className="rd-meta">Start Date: {settings.start_date}</p>
       </section>
 
-      <section>
+      <section id="rotation">
         <h2>Format Rotation</h2>
         <div className="rd-rotation-list">
           {settings.format_rotation.map((format, i) => (
@@ -343,7 +358,7 @@ export function Settings(): React.ReactElement {
         />
       </section>
 
-      <section>
+      <section id="topics">
         <h2>Topic Deck</h2>
         <div className="rd-deck-counter">
           {inDeck.length} of {topics.length} remaining
@@ -410,7 +425,7 @@ export function Settings(): React.ReactElement {
       </section>
 
       {plan && (
-        <section>
+        <section id="reading-plan">
           <h2>Book Reading Plan</h2>
 
           {plan.total_chapters > 0 && (

--- a/frontend/src/styles/rd-theme.css
+++ b/frontend/src/styles/rd-theme.css
@@ -1001,6 +1001,56 @@ button.rd-danger-outline:hover {
 }
 
 /* ===================================================================
+   17a. Settings section navigation
+   =================================================================== */
+
+.rd-section-nav {
+  position: sticky;
+  top: 0;
+  z-index: 90;
+  display: flex;
+  gap: var(--rd-space-xs);
+  padding: var(--rd-space-sm) var(--rd-space-md);
+  background: var(--rd-bg-card);
+  border: 1px solid var(--rd-border-subtle);
+  border-radius: var(--rd-radius);
+  box-shadow: var(--rd-shadow-sm);
+  margin-bottom: var(--rd-space-lg);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.rd-section-nav::-webkit-scrollbar {
+  display: none;
+}
+
+.rd-section-nav__link {
+  flex-shrink: 0;
+  padding: var(--rd-space-xs) var(--rd-space-md);
+  font-size: var(--rd-font-size-sm);
+  font-weight: 600;
+  color: var(--rd-text-muted);
+  text-decoration: none;
+  border-radius: var(--rd-radius-sm);
+  white-space: nowrap;
+  transition:
+    color var(--rd-duration) var(--rd-ease),
+    background-color var(--rd-duration) var(--rd-ease);
+}
+
+.rd-section-nav__link:hover {
+  color: var(--rd-accent);
+  background-color: var(--rd-bg-elevated);
+  text-decoration: none;
+}
+
+.rd-section-nav__link--active {
+  color: var(--rd-accent);
+  background-color: var(--rd-bg-elevated);
+}
+
+/* ===================================================================
    17. Settings page specifics
    =================================================================== */
 

--- a/frontend/tests/Settings.test.tsx
+++ b/frontend/tests/Settings.test.tsx
@@ -1,4 +1,4 @@
-/** Tests for Settings page sticky save bar. */
+/** Tests for Settings page section navigation and sticky save bar. */
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ToastProvider } from "../src/contexts/ToastContext";
@@ -68,6 +68,34 @@ describe("Settings", () => {
     (api.getTopics as jest.Mock).mockResolvedValue(mockTopics);
     (api.getReadingPlan as jest.Mock).mockResolvedValue(mockPlan);
     (api.getChapters as jest.Mock).mockResolvedValue(mockChapters);
+  });
+
+  it("renders section nav with correct links", async () => {
+    renderSettings();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Settings" }),
+      ).toBeInTheDocument();
+    });
+
+    const nav = screen.getByRole("navigation", { name: "Section navigation" });
+    expect(nav).toBeInTheDocument();
+
+    const links = nav.querySelectorAll("a");
+    expect(links).toHaveLength(4);
+
+    expect(links[0]).toHaveTextContent("Meeting");
+    expect(links[0]).toHaveAttribute("href", "#meeting");
+
+    expect(links[1]).toHaveTextContent("Rotation");
+    expect(links[1]).toHaveAttribute("href", "#rotation");
+
+    expect(links[2]).toHaveTextContent("Topics");
+    expect(links[2]).toHaveAttribute("href", "#topics");
+
+    expect(links[3]).toHaveTextContent("Reading Plan");
+    expect(links[3]).toHaveAttribute("href", "#reading-plan");
   });
 
   it("renders settings page", async () => {


### PR DESCRIPTION
## Summary
- Adds sticky sub-navigation bar to Settings page with anchor links to each section
- Sections: Meeting | Rotation | Topics | Reading Plan
- Smooth scroll on click, horizontal scroll on narrow screens
- Uses existing design tokens and BEM naming convention

## Test plan
- [ ] Verify section nav renders with 4 links
- [ ] Verify each link scrolls to correct section
- [ ] Verify sticky behavior on scroll
- [ ] Verify horizontal scroll on mobile viewports
- [ ] All existing Settings tests still pass

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)