### PR TITLE
feat: add loading skeleton placeholders

### DIFF
--- a/frontend/src/components/Skeleton.tsx
+++ b/frontend/src/components/Skeleton.tsx
@@ -1,0 +1,24 @@
+/** Skeleton loading placeholder with pulsing bars. */
+
+interface SkeletonProps {
+  lines?: number;
+  showHeader?: boolean;
+}
+
+export function Skeleton({
+  lines = 3,
+  showHeader = true,
+}: SkeletonProps): React.ReactElement {
+  return (
+    <div className="rd-skeleton" aria-busy="true" aria-label="Loading content">
+      {showHeader && <div className="rd-skeleton__header" />}
+      {Array.from({ length: lines }, (_, i) => (
+        <div
+          key={i}
+          className="rd-skeleton__line"
+          style={{ width: `${85 - i * 10}%` }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -19,6 +19,7 @@ import type {
   UpcomingMeeting,
   UpcomingMeetingBrief,
 } from "../types/index";
+import { Skeleton } from "../components/Skeleton";
 import { formatMeetingDate, formatMeetingTime } from "../utils/dates";
 
 export function Landing(): React.ReactElement {
@@ -199,7 +200,7 @@ export function Landing(): React.ReactElement {
     }
   }, [meeting, isCancelling, refresh, showToast]);
 
-  if (loading) return <p aria-busy="true">Loading...</p>;
+  if (loading) return <Skeleton lines={4} />;
   if (error) return <p role="alert">{error}</p>;
   if (!meeting) return <p>No upcoming meeting found.</p>;
 

--- a/frontend/src/pages/Log.tsx
+++ b/frontend/src/pages/Log.tsx
@@ -10,6 +10,7 @@ import {
 import { useShowToast } from "../contexts/ToastContext";
 import { useLogFilters } from "../hooks/useLogFilters";
 import type { MeetingLogEntry, MeetingLogUpdate } from "../types/index";
+import { Skeleton } from "../components/Skeleton";
 import { formatLogDate } from "../utils/dates";
 
 const FORMAT_OPTIONS = ["", "Speaker", "Topic", "Book Study"];
@@ -66,7 +67,7 @@ export function Log(): React.ReactElement {
     }
   }
 
-  if (loading) return <p aria-busy="true">Loading...</p>;
+  if (loading) return <Skeleton lines={4} />;
   if (error) return <p role="alert">{error}</p>;
 
   return (

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { RotationCalendar } from "../components/RotationCalendar";
+import { Skeleton } from "../components/Skeleton";
 import {
   addChapterToPlan,
   createTopic,
@@ -252,7 +253,7 @@ export function Settings(): React.ReactElement {
     );
   }, []);
 
-  if (loading) return <p aria-busy="true">Loading...</p>;
+  if (loading) return <Skeleton lines={4} />;
   if (error) return <p role="alert">{error}</p>;
   if (!settings) return <p>No settings found.</p>;
 

--- a/frontend/src/styles/rd-theme.css
+++ b/frontend/src/styles/rd-theme.css
@@ -574,6 +574,37 @@ p[role="alert"] {
   padding: var(--rd-space-2xl);
 }
 
+.rd-skeleton {
+  padding: var(--rd-space-xl);
+}
+
+.rd-skeleton__header {
+  height: 1.5rem;
+  width: 40%;
+  background: var(--rd-sand);
+  border-radius: var(--rd-radius-sm);
+  margin-bottom: var(--rd-space-md);
+  animation: rd-pulse 1.5s ease-in-out infinite;
+}
+
+.rd-skeleton__line {
+  height: 0.875rem;
+  background: var(--rd-sand);
+  border-radius: var(--rd-radius-sm);
+  margin-bottom: var(--rd-space-sm);
+  animation: rd-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes rd-pulse {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
 /* ===================================================================
    14. Login page
    =================================================================== */

--- a/frontend/tests/Landing.test.tsx
+++ b/frontend/tests/Landing.test.tsx
@@ -156,7 +156,11 @@ describe("Landing", () => {
   it("shows loading state initially", () => {
     getUpcomingMeeting.mockReturnValue(new Promise(() => {}));
     renderLanding();
-    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    expect(screen.getByLabelText("Loading content")).toBeInTheDocument();
+    expect(screen.getByLabelText("Loading content")).toHaveAttribute(
+      "aria-busy",
+      "true",
+    );
   });
 
   it("shows error message on API failure", async () => {

--- a/frontend/tests/Log.test.tsx
+++ b/frontend/tests/Log.test.tsx
@@ -100,7 +100,11 @@ describe("Log", () => {
   it("shows loading state initially", () => {
     getMeetingLog.mockReturnValue(new Promise(() => {}));
     renderLog();
-    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    expect(screen.getByLabelText("Loading content")).toBeInTheDocument();
+    expect(screen.getByLabelText("Loading content")).toHaveAttribute(
+      "aria-busy",
+      "true",
+    );
   });
 
   it("shows error message on API failure", async () => {

--- a/frontend/tests/Skeleton.test.tsx
+++ b/frontend/tests/Skeleton.test.tsx
@@ -1,0 +1,49 @@
+/** Tests for Skeleton loading placeholder component. */
+
+import { render, screen } from "@testing-library/react";
+import { Skeleton } from "../src/components/Skeleton";
+
+describe("Skeleton", () => {
+  it("renders with aria-busy attribute", () => {
+    render(<Skeleton />);
+    const skeleton = screen.getByLabelText("Loading content");
+    expect(skeleton).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("renders default 3 lines", () => {
+    const { container } = render(<Skeleton />);
+    const lines = container.querySelectorAll(".rd-skeleton__line");
+    expect(lines).toHaveLength(3);
+  });
+
+  it("renders custom number of lines", () => {
+    const { container } = render(<Skeleton lines={5} />);
+    const lines = container.querySelectorAll(".rd-skeleton__line");
+    expect(lines).toHaveLength(5);
+  });
+
+  it("renders header by default", () => {
+    const { container } = render(<Skeleton />);
+    expect(container.querySelector(".rd-skeleton__header")).toBeInTheDocument();
+  });
+
+  it("hides header when showHeader is false", () => {
+    const { container } = render(<Skeleton showHeader={false} />);
+    expect(
+      container.querySelector(".rd-skeleton__header"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("applies decreasing widths to lines", () => {
+    const { container } = render(<Skeleton lines={3} />);
+    const lines = container.querySelectorAll(".rd-skeleton__line");
+    expect(lines[0]).toHaveStyle({ width: "85%" });
+    expect(lines[1]).toHaveStyle({ width: "75%" });
+    expect(lines[2]).toHaveStyle({ width: "65%" });
+  });
+
+  it("has rd-skeleton class on root element", () => {
+    const { container } = render(<Skeleton />);
+    expect(container.querySelector(".rd-skeleton")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces "Loading..." text with animated skeleton UI on Landing, Log, and Settings pages
- New reusable `Skeleton` component with configurable lines and header
- CSS-only pulse animation using existing design tokens
- Accessible: `aria-busy="true"` and `aria-label="Loading content"`

## Test plan
- [ ] Verify skeleton renders with correct aria attributes
- [ ] Verify configurable line count and header visibility
- [ ] Verify all 3 pages use skeleton instead of text
- [ ] All existing page tests updated and passing

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)