### PR TITLE
feat: show 5th-week format note in rotation settings

### DIFF
--- a/frontend/src/components/RotationCalendar.tsx
+++ b/frontend/src/components/RotationCalendar.tsx
@@ -31,7 +31,7 @@ function toIsoDate(d: Date): string {
 export function RotationCalendar({
   meetingDay,
   formatRotation,
-  count = 8,
+  count = 10,
 }: RotationCalendarProps): React.ReactElement {
   // Convert meetingDay (0=Mon, 6=Sun) to JS day (0=Sun, 6=Sat)
   const jsMeetingDay = meetingDay === 6 ? 0 : meetingDay + 1;

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -341,6 +341,14 @@ export function Settings(): React.ReactElement {
           startDate={settings.start_date}
           formatRotation={settings.format_rotation}
         />
+        {settings.format_rotation.length < 5 && (
+          <p className="rd-meta">
+            Note: Months with a 5th {DAYS_OF_WEEK[settings.meeting_day]} will
+            use the{" "}
+            {settings.format_rotation[4 % settings.format_rotation.length]}{" "}
+            format (position {(4 % settings.format_rotation.length) + 1}).
+          </p>
+        )}
       </section>
 
       <section>

--- a/frontend/tests/RotationCalendar.test.tsx
+++ b/frontend/tests/RotationCalendar.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from "@testing-library/react";
 import { RotationCalendar } from "../src/components/RotationCalendar";
 
 describe("RotationCalendar", () => {
-  it("renders 8 meetings by default", () => {
+  it("renders 10 meetings by default", () => {
     const { container } = render(
       <RotationCalendar
         meetingDay={6}
@@ -13,7 +13,7 @@ describe("RotationCalendar", () => {
       />,
     );
     const rows = container.querySelectorAll(".rd-rotation-calendar__row");
-    expect(rows.length).toBe(8);
+    expect(rows.length).toBe(10);
   });
 
   it("renders custom count of meetings", () => {

--- a/frontend/tests/Settings.test.tsx
+++ b/frontend/tests/Settings.test.tsx
@@ -473,4 +473,35 @@ describe("Settings", () => {
 
     expect(screen.queryByText(/last used/)).not.toBeInTheDocument();
   });
+
+  it("shows 5th-week note when rotation length is less than 5", async () => {
+    renderSettings();
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Test Meeting")).toBeInTheDocument();
+    });
+
+    // Default mock has 3-item rotation: ["Speaker", "Topic", "Book Study"]
+    // 4 % 3 = 1, so position 2, format = "Topic"
+    expect(
+      screen.getByText(
+        /Months with a 5th Sunday will use the Topic format \(position 2\)/,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show 5th-week note when rotation length is 5 or more", async () => {
+    const fiveItemSettings: GroupSettings = {
+      ...mockSettings,
+      format_rotation: ["Speaker", "Topic", "Book Study", "Speaker", "Topic"],
+    };
+    (api.getSettings as jest.Mock).mockResolvedValue(fiveItemSettings);
+    renderSettings();
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Test Meeting")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/Months with a 5th/)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- Shows informational note when rotation is shorter than 5 slots explaining which format will be used on 5th-week months
- Example: "Months with a 5th Sunday will use the Topic format (position 2)."
- Expanded RotationCalendar from 8 to 10 weeks for better wrap-around visibility

## Test plan
- [ ] Verify note appears when rotation length < 5
- [ ] Verify note shows correct day name, format, and position
- [ ] Verify note is hidden when rotation length >= 5
- [ ] Verify calendar shows 10 rows instead of 8
- [ ] All existing tests still pass

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)