### PR TITLE
fix: guard formatMeetingTime against malformed input

### DIFF
--- a/frontend/src/utils/dates.ts
+++ b/frontend/src/utils/dates.ts
@@ -48,6 +48,7 @@ export function formatShortDate(isoDate: string): string {
 export function formatMeetingTime(timeStr: string | null): string | null {
   if (!timeStr) return null;
   const [hours, minutes] = timeStr.split(":").map(Number);
+  if (isNaN(hours) || isNaN(minutes)) return null;
   const date = new Date(2000, 0, 1, hours, minutes);
   return date.toLocaleTimeString("en-US", {
     hour: "numeric",

--- a/frontend/tests/dates.test.ts
+++ b/frontend/tests/dates.test.ts
@@ -52,4 +52,16 @@ describe("formatMeetingTime", () => {
   it("returns null for empty string", () => {
     expect(formatMeetingTime("")).toBeNull();
   });
+
+  it("returns null for fully malformed input", () => {
+    expect(formatMeetingTime("abc:zz")).toBeNull();
+  });
+
+  it("returns null when minutes are malformed", () => {
+    expect(formatMeetingTime("12:abc")).toBeNull();
+  });
+
+  it("returns null for non-time string", () => {
+    expect(formatMeetingTime("not-a-time")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- Adds NaN guard to `formatMeetingTime` so malformed inputs like "abc:zz" return `null` instead of "Invalid Date"
- Three new test cases for malformed input handling

## Test plan
- [ ] Verify `formatMeetingTime("abc:zz")` returns null
- [ ] Verify `formatMeetingTime("12:abc")` returns null
- [ ] Verify `formatMeetingTime("not-a-time")` returns null
- [ ] All existing date utility tests still pass

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)