### PR TITLE
feat: add Danger Zone and inline confirmations

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -54,6 +54,7 @@ export function Settings(): React.ReactElement {
   const [editChapterIds, setEditChapterIds] = useState<number[]>([]);
   const [selectedChapterIds, setSelectedChapterIds] = useState<number[]>([]);
   const [addingChapters, setAddingChapters] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<string | null>(null);
   const showToast = useShowToast();
 
   const isDirty = useMemo(() => {
@@ -156,20 +157,20 @@ export function Settings(): React.ReactElement {
   );
 
   const handleDeleteTopic = useCallback(async (topicId: number) => {
-    if (!window.confirm("Remove this topic from the deck?")) return;
     try {
       await deleteTopic(topicId);
       setTopics(await getTopics());
+      setConfirmAction(null);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Failed to delete topic");
     }
   }, []);
 
   const handleReshuffle = useCallback(async () => {
-    if (!window.confirm("Reshuffle the deck? All drawn topics return.")) return;
     try {
       await reshuffleTopics();
       setTopics(await getTopics());
+      setConfirmAction(null);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Failed to reshuffle");
     }
@@ -236,10 +237,10 @@ export function Settings(): React.ReactElement {
   }, []);
 
   const handleDeleteAssignment = useCallback(async (assignmentId: number) => {
-    if (!window.confirm("Delete this assignment?")) return;
     try {
       await deleteAssignment(assignmentId);
       setPlan(await getReadingPlan());
+      setConfirmAction(null);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Failed to delete");
     }
@@ -283,6 +284,9 @@ export function Settings(): React.ReactElement {
         </a>
         <a className="rd-section-nav__link" href="#reading-plan">
           Reading Plan
+        </a>
+        <a className="rd-section-nav__link" href="#danger-zone">
+          Danger Zone
         </a>
       </nav>
 
@@ -386,13 +390,32 @@ export function Settings(): React.ReactElement {
                   </span>
                 )}
               </span>
-              <button
-                type="button"
-                className="rd-ghost"
-                onClick={() => handleDeleteTopic(t.id)}
-              >
-                Remove
-              </button>
+              {confirmAction === `delete-topic-${t.id}` ? (
+                <span className="rd-inline-confirm">
+                  <button
+                    type="button"
+                    className="rd-danger"
+                    onClick={() => handleDeleteTopic(t.id)}
+                  >
+                    Confirm Remove
+                  </button>
+                  <button
+                    type="button"
+                    className="outline"
+                    onClick={() => setConfirmAction(null)}
+                  >
+                    Cancel
+                  </button>
+                </span>
+              ) : (
+                <button
+                  type="button"
+                  className="rd-ghost"
+                  onClick={() => setConfirmAction(`delete-topic-${t.id}`)}
+                >
+                  Remove
+                </button>
+              )}
             </li>
           ))}
         </ul>
@@ -427,10 +450,6 @@ export function Settings(): React.ReactElement {
           />
           <button type="submit">Add Topic</button>
         </form>
-
-        <button type="button" className="outline" onClick={handleReshuffle}>
-          Reshuffle Deck
-        </button>
       </section>
 
       {plan && (
@@ -598,13 +617,34 @@ export function Settings(): React.ReactElement {
                           >
                             Edit
                           </button>
-                          <button
-                            type="button"
-                            className="rd-ghost"
-                            onClick={() => handleDeleteAssignment(a.id)}
-                          >
-                            Delete
-                          </button>
+                          {confirmAction === `delete-assignment-${a.id}` ? (
+                            <>
+                              <button
+                                type="button"
+                                className="rd-danger"
+                                onClick={() => handleDeleteAssignment(a.id)}
+                              >
+                                Confirm Delete
+                              </button>
+                              <button
+                                type="button"
+                                className="outline"
+                                onClick={() => setConfirmAction(null)}
+                              >
+                                Cancel
+                              </button>
+                            </>
+                          ) : (
+                            <button
+                              type="button"
+                              className="rd-ghost"
+                              onClick={() =>
+                                setConfirmAction(`delete-assignment-${a.id}`)
+                              }
+                            >
+                              Delete
+                            </button>
+                          )}
                         </span>
                       </div>
                     )}
@@ -615,6 +655,37 @@ export function Settings(): React.ReactElement {
           )}
         </section>
       )}
+
+      <section id="danger-zone" className="rd-danger-zone">
+        <h2>Danger Zone</h2>
+        {confirmAction === "reshuffle" ? (
+          <div className="rd-danger-zone__confirm">
+            <p>Reshuffle the deck? All drawn topics will return.</p>
+            <button
+              type="button"
+              className="rd-danger"
+              onClick={handleReshuffle}
+            >
+              Confirm Reshuffle
+            </button>
+            <button
+              type="button"
+              className="outline"
+              onClick={() => setConfirmAction(null)}
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            className="rd-danger-outline"
+            onClick={() => setConfirmAction("reshuffle")}
+          >
+            Reshuffle Deck
+          </button>
+        )}
+      </section>
 
       {isDirty && (
         <div className="rd-sticky-bar" role="status">

--- a/frontend/src/styles/rd-theme.css
+++ b/frontend/src/styles/rd-theme.css
@@ -1252,6 +1252,37 @@ button.rd-danger-outline:hover {
   font-size: var(--rd-font-size-sm);
 }
 
+/* Danger Zone */
+.rd-danger-zone {
+  border: 2px solid var(--rd-danger);
+  border-radius: var(--rd-radius-lg);
+  padding: var(--rd-space-lg) var(--rd-space-xl);
+  margin-bottom: var(--rd-space-lg);
+}
+
+.rd-danger-zone h2 {
+  color: var(--rd-danger);
+  border-bottom-color: var(--rd-danger);
+}
+
+.rd-danger-zone__confirm {
+  display: flex;
+  align-items: center;
+  gap: var(--rd-space-sm);
+  flex-wrap: wrap;
+}
+
+.rd-danger-zone__confirm p {
+  flex: 1 1 100%;
+  margin-bottom: var(--rd-space-sm);
+}
+
+/* Inline confirmation for destructive actions */
+.rd-inline-confirm {
+  display: inline-flex;
+  gap: var(--rd-space-xs);
+}
+
 /* Sticky save bar */
 .rd-sticky-bar {
   position: sticky;

--- a/frontend/tests/Settings.test.tsx
+++ b/frontend/tests/Settings.test.tsx
@@ -83,7 +83,7 @@ describe("Settings", () => {
     expect(nav).toBeInTheDocument();
 
     const links = nav.querySelectorAll("a");
-    expect(links).toHaveLength(4);
+    expect(links).toHaveLength(5);
 
     expect(links[0]).toHaveTextContent("Meeting");
     expect(links[0]).toHaveAttribute("href", "#meeting");
@@ -96,6 +96,9 @@ describe("Settings", () => {
 
     expect(links[3]).toHaveTextContent("Reading Plan");
     expect(links[3]).toHaveAttribute("href", "#reading-plan");
+
+    expect(links[4]).toHaveTextContent("Danger Zone");
+    expect(links[4]).toHaveAttribute("href", "#danger-zone");
   });
 
   it("renders settings page", async () => {
@@ -531,5 +534,261 @@ describe("Settings", () => {
     });
 
     expect(screen.queryByText(/Months with a 5th/)).not.toBeInTheDocument();
+  });
+
+  it("renders Danger Zone section with reshuffle button", async () => {
+    renderSettings();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Danger Zone" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Reshuffle Deck" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows inline confirmation for reshuffle", async () => {
+    renderSettings();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Reshuffle Deck" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Reshuffle Deck" }));
+
+    expect(
+      screen.getByText("Reshuffle the deck? All drawn topics will return."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Confirm Reshuffle" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("cancels reshuffle on cancel click", async () => {
+    renderSettings();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Reshuffle Deck" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Reshuffle Deck" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(
+      screen.getByRole("button", { name: "Reshuffle Deck" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Reshuffle the deck? All drawn topics will return."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("executes reshuffle on confirm", async () => {
+    (api.reshuffleTopics as jest.Mock).mockResolvedValue(undefined);
+    (api.getTopics as jest.Mock).mockResolvedValue(mockTopics);
+    renderSettings();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Reshuffle Deck" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Reshuffle Deck" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm Reshuffle" }));
+
+    await waitFor(() => {
+      expect(api.reshuffleTopics).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("shows inline confirmation when deleting a topic", async () => {
+    renderSettings();
+
+    await waitFor(() => {
+      expect(screen.getByText("Topic 1")).toBeInTheDocument();
+    });
+
+    const topicItem = screen.getByText("Topic 1").closest("li")!;
+    const removeBtn = topicItem.querySelector("button")!;
+    fireEvent.click(removeBtn);
+
+    expect(
+      screen.getByRole("button", { name: "Confirm Remove" }),
+    ).toBeInTheDocument();
+  });
+
+  it("cancels topic deletion on cancel click", async () => {
+    renderSettings();
+
+    await waitFor(() => {
+      expect(screen.getByText("Topic 1")).toBeInTheDocument();
+    });
+
+    const topicItem = screen.getByText("Topic 1").closest("li")!;
+    const removeBtn = topicItem.querySelector("button")!;
+    fireEvent.click(removeBtn);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(
+      screen.queryByRole("button", { name: "Confirm Remove" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("executes topic deletion on confirm", async () => {
+    (api.deleteTopic as jest.Mock).mockResolvedValue(undefined);
+    renderSettings();
+
+    await waitFor(() => {
+      expect(screen.getByText("Topic 1")).toBeInTheDocument();
+    });
+
+    // Mock getTopics to return empty after deletion
+    (api.getTopics as jest.Mock).mockResolvedValue([]);
+
+    const topicItem = screen.getByText("Topic 1").closest("li")!;
+    const removeBtn = topicItem.querySelector("button")!;
+    fireEvent.click(removeBtn);
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm Remove" }));
+
+    await waitFor(() => {
+      expect(api.deleteTopic).toHaveBeenCalledWith(1);
+    });
+  });
+
+  it("shows inline confirmation when deleting an assignment", async () => {
+    const planWithAssignment: ReadingPlanStatus = {
+      ...mockPlan,
+      total_chapters: 3,
+      assigned_chapters: 1,
+      total_pages: 6,
+      assigned_pages: 1,
+      completed_assignments: [
+        {
+          id: 10,
+          assignment_order: 1,
+          chapters: [
+            {
+              id: 1,
+              order: 1,
+              start_page: "1",
+              end_page: "10",
+              title: "Preface",
+              page_count: 9,
+            },
+          ],
+          total_pages: 9,
+          meeting_date: null,
+        },
+      ],
+    };
+    (api.getReadingPlan as jest.Mock).mockResolvedValue(planWithAssignment);
+    renderSettings();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Preface/)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(
+      screen.getByRole("button", { name: "Confirm Delete" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("cancels assignment deletion on cancel click", async () => {
+    const planWithAssignment: ReadingPlanStatus = {
+      ...mockPlan,
+      total_chapters: 3,
+      assigned_chapters: 1,
+      total_pages: 6,
+      assigned_pages: 1,
+      completed_assignments: [
+        {
+          id: 10,
+          assignment_order: 1,
+          chapters: [
+            {
+              id: 1,
+              order: 1,
+              start_page: "1",
+              end_page: "10",
+              title: "Preface",
+              page_count: 9,
+            },
+          ],
+          total_pages: 9,
+          meeting_date: null,
+        },
+      ],
+    };
+    (api.getReadingPlan as jest.Mock).mockResolvedValue(planWithAssignment);
+    renderSettings();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Preface/)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Confirm Delete" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("executes assignment deletion on confirm", async () => {
+    const planWithAssignment: ReadingPlanStatus = {
+      ...mockPlan,
+      total_chapters: 3,
+      assigned_chapters: 1,
+      total_pages: 6,
+      assigned_pages: 1,
+      completed_assignments: [
+        {
+          id: 10,
+          assignment_order: 1,
+          chapters: [
+            {
+              id: 1,
+              order: 1,
+              start_page: "1",
+              end_page: "10",
+              title: "Preface",
+              page_count: 9,
+            },
+          ],
+          total_pages: 9,
+          meeting_date: null,
+        },
+      ],
+    };
+    (api.getReadingPlan as jest.Mock)
+      .mockResolvedValueOnce(planWithAssignment)
+      .mockResolvedValue({ ...mockPlan, completed_assignments: [] });
+    (api.deleteAssignment as jest.Mock).mockResolvedValue(undefined);
+    renderSettings();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Preface/)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm Delete" }));
+
+    await waitFor(() => {
+      expect(api.deleteAssignment).toHaveBeenCalledWith(10);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Groups destructive actions (reshuffle deck) into a red-bordered "Danger Zone" section
- Replaces all `window.confirm()` calls with accessible inline confirmation patterns
- Inline confirm for: topic deletion, assignment deletion, and deck reshuffle
- Adds Danger Zone link to section navigation

## Test plan
- [ ] Verify Danger Zone section renders with reshuffle button
- [ ] Verify inline confirmation appears on destructive action click
- [ ] Verify cancel returns to normal state
- [ ] Verify confirm executes the action
- [ ] All existing Settings tests still pass

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)