### PR TITLE
feat: add retry buttons on failed requests

### DIFF
--- a/frontend/src/components/ErrorWithRetry.tsx
+++ b/frontend/src/components/ErrorWithRetry.tsx
@@ -1,0 +1,20 @@
+/** Error display with a retry button for failed requests. */
+
+interface ErrorWithRetryProps {
+  message: string;
+  onRetry: () => void;
+}
+
+export function ErrorWithRetry({
+  message,
+  onRetry,
+}: ErrorWithRetryProps): React.ReactElement {
+  return (
+    <div className="rd-error" role="alert">
+      <p>{message}</p>
+      <button type="button" className="outline" onClick={onRetry}>
+        Retry
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -19,6 +19,7 @@ import type {
   UpcomingMeeting,
   UpcomingMeetingBrief,
 } from "../types/index";
+import { ErrorWithRetry } from "../components/ErrorWithRetry";
 import { Skeleton } from "../components/Skeleton";
 import { formatMeetingDate, formatMeetingTime } from "../utils/dates";
 
@@ -201,7 +202,17 @@ export function Landing(): React.ReactElement {
   }, [meeting, isCancelling, refresh, showToast]);
 
   if (loading) return <Skeleton lines={4} />;
-  if (error) return <p role="alert">{error}</p>;
+  if (error)
+    return (
+      <ErrorWithRetry
+        message={error}
+        onRetry={() => {
+          setError(null);
+          setLoading(true);
+          refresh().finally(() => setLoading(false));
+        }}
+      />
+    );
   if (!meeting) return <p>No upcoming meeting found.</p>;
 
   const formattedTime = formatMeetingTime(meeting.meeting_time);

--- a/frontend/src/pages/Log.tsx
+++ b/frontend/src/pages/Log.tsx
@@ -1,6 +1,6 @@
 /** Meeting log page - shows history of past meetings. */
 
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import {
   getCsvExportUrl,
   getMeetingLog,
@@ -10,6 +10,7 @@ import {
 import { useShowToast } from "../contexts/ToastContext";
 import { useLogFilters } from "../hooks/useLogFilters";
 import type { MeetingLogEntry, MeetingLogUpdate } from "../types/index";
+import { ErrorWithRetry } from "../components/ErrorWithRetry";
 import { Skeleton } from "../components/Skeleton";
 import { formatLogDate } from "../utils/dates";
 
@@ -23,7 +24,9 @@ export function Log(): React.ReactElement {
   const [editForm, setEditForm] = useState<MeetingLogUpdate>({});
   const showToast = useShowToast();
 
-  useEffect(() => {
+  const loadEntries = useCallback(() => {
+    setError(null);
+    setLoading(true);
     getMeetingLog()
       .then(setEntries)
       .catch((err: unknown) =>
@@ -31,6 +34,10 @@ export function Log(): React.ReactElement {
       )
       .finally(() => setLoading(false));
   }, []);
+
+  useEffect(() => {
+    loadEntries();
+  }, [loadEntries]);
 
   const {
     filters,
@@ -68,7 +75,7 @@ export function Log(): React.ReactElement {
   }
 
   if (loading) return <Skeleton lines={4} />;
-  if (error) return <p role="alert">{error}</p>;
+  if (error) return <ErrorWithRetry message={error} onRetry={loadEntries} />;
 
   return (
     <main className="rd-log">

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,6 +1,7 @@
 /** Settings page - group configuration. */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { ErrorWithRetry } from "../components/ErrorWithRetry";
 import { RotationCalendar } from "../components/RotationCalendar";
 import { Skeleton } from "../components/Skeleton";
 import {
@@ -61,7 +62,9 @@ export function Settings(): React.ReactElement {
     return JSON.stringify(settings) !== JSON.stringify(savedSettings);
   }, [settings, savedSettings]);
 
-  useEffect(() => {
+  const loadSettings = useCallback(() => {
+    setError(null);
+    setLoading(true);
     Promise.all([getSettings(), getTopics(), getReadingPlan(), getChapters()])
       .then(([s, t, p, c]) => {
         setSettings(s);
@@ -75,6 +78,10 @@ export function Settings(): React.ReactElement {
       )
       .finally(() => setLoading(false));
   }, []);
+
+  useEffect(() => {
+    loadSettings();
+  }, [loadSettings]);
 
   // Warn on navigation away with unsaved changes
   useEffect(() => {
@@ -254,7 +261,7 @@ export function Settings(): React.ReactElement {
   }, []);
 
   if (loading) return <Skeleton lines={4} />;
-  if (error) return <p role="alert">{error}</p>;
+  if (error) return <ErrorWithRetry message={error} onRetry={loadSettings} />;
   if (!settings) return <p>No settings found.</p>;
 
   const inDeck = topics.filter((t) => !t.is_drawn);

--- a/frontend/src/styles/rd-theme.css
+++ b/frontend/src/styles/rd-theme.css
@@ -548,6 +548,17 @@ li button {
   margin: var(--rd-space-xs) 0;
 }
 
+.rd-error {
+  text-align: center;
+  padding: var(--rd-space-xl);
+}
+
+.rd-error p {
+  color: var(--rd-danger);
+  font-weight: 600;
+  margin-bottom: var(--rd-space-md);
+}
+
 /* Error alerts */
 p[role="alert"] {
   background: linear-gradient(

--- a/frontend/tests/ErrorWithRetry.test.tsx
+++ b/frontend/tests/ErrorWithRetry.test.tsx
@@ -1,0 +1,30 @@
+/** Tests for ErrorWithRetry component. */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ErrorWithRetry } from "../src/components/ErrorWithRetry";
+
+describe("ErrorWithRetry", () => {
+  it("renders the error message", () => {
+    render(
+      <ErrorWithRetry message="Something went wrong" onRetry={jest.fn()} />,
+    );
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+  });
+
+  it("has role=alert for accessibility", () => {
+    render(<ErrorWithRetry message="Oops" onRetry={jest.fn()} />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("renders a Retry button", () => {
+    render(<ErrorWithRetry message="Oops" onRetry={jest.fn()} />);
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+
+  it("calls onRetry when Retry button is clicked", () => {
+    const onRetry = jest.fn();
+    render(<ErrorWithRetry message="Oops" onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- New `ErrorWithRetry` component replaces bare error text on all pages
- Landing, Log, and Settings pages now show a Retry button alongside errors
- Loading logic extracted to reusable callbacks for retry support
- Accessible: maintains `role="alert"` on error container

## Test plan
- [ ] Verify ErrorWithRetry renders message and button
- [ ] Verify Retry button calls the retry callback
- [ ] Verify all 3 pages use ErrorWithRetry
- [ ] All existing page tests still pass

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)