### PR TITLE
feat: add mobile hamburger navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,13 +31,28 @@ function AuthenticatedApp({
 
   return (
     <>
-      <nav className="container">
+      <nav className="container rd-nav">
         <ul>
           <li>
             <strong>{groupName}</strong>
           </li>
         </ul>
-        <ul>
+        <input
+          type="checkbox"
+          id="rd-nav-toggle"
+          className="rd-nav__toggle"
+          aria-label="Toggle navigation"
+        />
+        <label
+          htmlFor="rd-nav-toggle"
+          className="rd-nav__hamburger"
+          aria-hidden="true"
+        >
+          <span />
+          <span />
+          <span />
+        </label>
+        <ul className="rd-nav__links">
           <li>
             <NavLink to="/" end>
               Home

--- a/frontend/src/styles/rd-theme.css
+++ b/frontend/src/styles/rd-theme.css
@@ -276,6 +276,79 @@ nav.container button.outline:hover {
 }
 
 /* ===================================================================
+   5a. Mobile hamburger navigation
+   =================================================================== */
+
+/* Hamburger toggle — hidden by default */
+.rd-nav__toggle {
+  display: none;
+}
+
+.rd-nav__hamburger {
+  display: none;
+  cursor: pointer;
+  padding: var(--rd-space-sm);
+  min-height: 44px;
+  min-width: 44px;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.rd-nav__hamburger span {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background: var(--rd-text);
+  border-radius: 1px;
+  transition: all 0.3s var(--rd-ease);
+}
+
+@media (max-width: 768px) {
+  .rd-nav__hamburger {
+    display: flex;
+  }
+
+  .rd-nav__links {
+    display: none;
+    flex-direction: column;
+    width: 100%;
+    padding: var(--rd-space-sm) 0;
+  }
+
+  .rd-nav__toggle:checked ~ .rd-nav__links {
+    display: flex;
+  }
+
+  /* Hamburger animation */
+  .rd-nav__toggle:checked ~ .rd-nav__hamburger span:nth-child(1) {
+    transform: rotate(45deg) translate(5px, 5px);
+  }
+
+  .rd-nav__toggle:checked ~ .rd-nav__hamburger span:nth-child(2) {
+    opacity: 0;
+  }
+
+  .rd-nav__toggle:checked ~ .rd-nav__hamburger span:nth-child(3) {
+    transform: rotate(-45deg) translate(5px, -5px);
+  }
+
+  /* Touch targets */
+  .rd-nav__links a,
+  .rd-nav__links button {
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    padding: var(--rd-space-sm) var(--rd-space-md);
+  }
+
+  nav.container {
+    flex-wrap: wrap;
+  }
+}
+
+/* ===================================================================
    6. Buttons
    =================================================================== */
 

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -165,4 +165,44 @@ describe("App", () => {
       expect(screen.getByText("RD Log")).toBeInTheDocument();
     });
   });
+
+  describe("hamburger navigation", () => {
+    beforeEach(() => {
+      mockUseAuth.mockReturnValue(authState);
+      (api.getSettings as jest.Mock).mockReturnValue(new Promise(() => {}));
+    });
+
+    it("renders hamburger toggle on mobile", () => {
+      render(
+        <MemoryRouter>
+          <App />
+        </MemoryRouter>,
+      );
+
+      const toggle = screen.getByLabelText("Toggle navigation");
+      expect(toggle).toBeInTheDocument();
+      expect(toggle).toHaveAttribute("type", "checkbox");
+
+      const hamburger = toggle.nextElementSibling;
+      expect(hamburger).toBeInTheDocument();
+      expect(hamburger?.tagName).toBe("LABEL");
+    });
+
+    it("nav links are still present", () => {
+      render(
+        <MemoryRouter>
+          <App />
+        </MemoryRouter>,
+      );
+
+      expect(screen.getByRole("link", { name: "Home" })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Log" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: "Settings" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Log Out" }),
+      ).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- CSS-only hamburger menu using hidden checkbox toggle (no JavaScript needed)
- Nav links collapse behind hamburger icon on viewports < 768px
- Animated hamburger-to-X transition on toggle
- 44px minimum touch targets on mobile for accessibility
- Desktop layout unchanged

## Test plan
- [ ] Verify hamburger toggle checkbox renders
- [ ] Verify all nav links are still present in DOM
- [ ] Verify hamburger icon visible on narrow viewports
- [ ] Verify nav links toggle on checkbox click
- [ ] All existing App tests still pass

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)