### PR TITLE
refactor: migrate from fireEvent to userEvent in tests

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
+        "@testing-library/user-event": "14.6.1",
         "@types/jest": "^29.5.0",
         "@types/node": "^20.0.0",
         "@types/react": "19.2.14",
@@ -2570,6 +2571,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
+    "@testing-library/user-event": "14.6.1",
     "@types/jest": "^29.5.0",
     "@types/node": "^20.0.0",
     "@types/react": "19.2.14",

--- a/frontend/tests/ErrorWithRetry.test.tsx
+++ b/frontend/tests/ErrorWithRetry.test.tsx
@@ -1,6 +1,7 @@
 /** Tests for ErrorWithRetry component. */
 
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ErrorWithRetry } from "../src/components/ErrorWithRetry";
 
 describe("ErrorWithRetry", () => {
@@ -21,10 +22,11 @@ describe("ErrorWithRetry", () => {
     expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
   });
 
-  it("calls onRetry when Retry button is clicked", () => {
+  it("calls onRetry when Retry button is clicked", async () => {
+    const user = userEvent.setup();
     const onRetry = jest.fn();
     render(<ErrorWithRetry message="Oops" onRetry={onRetry} />);
-    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await user.click(screen.getByRole("button", { name: "Retry" }));
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/tests/Landing.test.tsx
+++ b/frontend/tests/Landing.test.tsx
@@ -1,6 +1,7 @@
 /** Tests for Landing page component with cancel/restore functionality. */
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import * as api from "../src/api/index";
 import { ToastProvider } from "../src/contexts/ToastContext";
 import { Landing } from "../src/pages/Landing";
@@ -279,6 +280,7 @@ describe("Landing", () => {
     });
 
     it("calls cancelMeeting with is_cancelled=true when Cancel clicked", async () => {
+      const user = userEvent.setup();
       getUpcomingMeeting.mockResolvedValue(baseMeeting);
       cancelMeeting.mockResolvedValue({});
       renderLanding();
@@ -289,7 +291,7 @@ describe("Landing", () => {
         ).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "Cancel Meeting" }));
+      await user.click(screen.getByRole("button", { name: "Cancel Meeting" }));
 
       await waitFor(() => {
         expect(cancelMeeting).toHaveBeenCalledWith("2026-02-22", true);
@@ -302,6 +304,7 @@ describe("Landing", () => {
     });
 
     it("disables Cancel Meeting button during API call", async () => {
+      const user = userEvent.setup();
       getUpcomingMeeting.mockResolvedValue(baseMeeting);
       let resolveCancel!: (value: unknown) => void;
       cancelMeeting.mockReturnValue(
@@ -317,7 +320,7 @@ describe("Landing", () => {
         ).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "Cancel Meeting" }));
+      await user.click(screen.getByRole("button", { name: "Cancel Meeting" }));
 
       expect(
         screen.getByRole("button", { name: "Cancel Meeting" }),
@@ -400,6 +403,7 @@ describe("Landing", () => {
     });
 
     it("calls cancelMeeting with is_cancelled=false when Restore clicked", async () => {
+      const user = userEvent.setup();
       getUpcomingMeeting.mockResolvedValue(cancelledMeeting);
       cancelMeeting.mockResolvedValue({});
       renderLanding();
@@ -410,7 +414,7 @@ describe("Landing", () => {
         ).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "Restore Meeting" }));
+      await user.click(screen.getByRole("button", { name: "Restore Meeting" }));
 
       await waitFor(() => {
         expect(cancelMeeting).toHaveBeenCalledWith("2026-02-22", false);
@@ -423,6 +427,7 @@ describe("Landing", () => {
     });
 
     it("disables Restore Meeting button during API call", async () => {
+      const user = userEvent.setup();
       getUpcomingMeeting.mockResolvedValue(cancelledMeeting);
       let resolveRestore!: (value: unknown) => void;
       cancelMeeting.mockReturnValue(
@@ -438,7 +443,7 @@ describe("Landing", () => {
         ).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "Restore Meeting" }));
+      await user.click(screen.getByRole("button", { name: "Restore Meeting" }));
 
       expect(
         screen.getByRole("button", { name: "Restore Meeting" }),
@@ -528,6 +533,7 @@ describe("Landing", () => {
     });
 
     it("calls undoTopicDraw when Undo is clicked", async () => {
+      const user = userEvent.setup();
       getUpcomingMeeting.mockResolvedValue(baseMeeting);
       undoTopicDraw.mockResolvedValue({});
       renderLanding();
@@ -538,7 +544,7 @@ describe("Landing", () => {
         ).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "Undo" }));
+      await user.click(screen.getByRole("button", { name: "Undo" }));
 
       await waitFor(() => {
         expect(undoTopicDraw).toHaveBeenCalled();
@@ -546,6 +552,7 @@ describe("Landing", () => {
     });
 
     it("calls undoTopicDraw then drawTopic when Re-draw is clicked", async () => {
+      const user = userEvent.setup();
       getUpcomingMeeting.mockResolvedValue(baseMeeting);
       undoTopicDraw.mockResolvedValue({});
       drawTopic.mockResolvedValue({});
@@ -557,7 +564,7 @@ describe("Landing", () => {
         ).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "Re-draw" }));
+      await user.click(screen.getByRole("button", { name: "Re-draw" }));
 
       await waitFor(() => {
         expect(undoTopicDraw).toHaveBeenCalled();
@@ -566,6 +573,7 @@ describe("Landing", () => {
     });
 
     it("shows toast when undo fails", async () => {
+      const user = userEvent.setup();
       getUpcomingMeeting.mockResolvedValue(baseMeeting);
       undoTopicDraw.mockRejectedValue(new Error("Undo failed"));
       renderLanding();
@@ -576,7 +584,7 @@ describe("Landing", () => {
         ).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "Undo" }));
+      await user.click(screen.getByRole("button", { name: "Undo" }));
 
       await waitFor(() => {
         expect(screen.getByText("Undo failed")).toBeInTheDocument();
@@ -612,6 +620,7 @@ describe("Landing", () => {
     });
 
     it("opens edit form pre-filled with current speaker name", async () => {
+      const user = userEvent.setup();
       getUpcomingMeeting.mockResolvedValue(speakerMeeting);
       renderLanding();
 
@@ -621,7 +630,7 @@ describe("Landing", () => {
         ).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "Edit speaker" }));
+      await user.click(screen.getByRole("button", { name: "Edit speaker" }));
 
       const input = screen.getByPlaceholderText("Speaker name");
       expect(input).toHaveValue("Jane Doe");
@@ -629,6 +638,7 @@ describe("Landing", () => {
     });
 
     it("calls scheduleSpeaker with new name on edit submit", async () => {
+      const user = userEvent.setup();
       getUpcomingMeeting.mockResolvedValue(speakerMeeting);
       scheduleSpeaker.mockResolvedValue({});
       renderLanding();
@@ -639,11 +649,13 @@ describe("Landing", () => {
         ).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "Edit speaker" }));
-      fireEvent.change(screen.getByPlaceholderText("Speaker name"), {
-        target: { value: "John Smith" },
-      });
-      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+      await user.click(screen.getByRole("button", { name: "Edit speaker" }));
+      await user.clear(screen.getByPlaceholderText("Speaker name"));
+      await user.type(
+        screen.getByPlaceholderText("Speaker name"),
+        "John Smith",
+      );
+      await user.click(screen.getByRole("button", { name: "Save" }));
 
       await waitFor(() => {
         expect(scheduleSpeaker).toHaveBeenCalledWith(
@@ -654,6 +666,7 @@ describe("Landing", () => {
     });
 
     it("calls unscheduleSpeaker when Remove is clicked", async () => {
+      const user = userEvent.setup();
       getUpcomingMeeting.mockResolvedValue(speakerMeeting);
       unscheduleSpeaker.mockResolvedValue({});
       renderLanding();
@@ -664,7 +677,7 @@ describe("Landing", () => {
         ).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "Remove speaker" }));
+      await user.click(screen.getByRole("button", { name: "Remove speaker" }));
 
       await waitFor(() => {
         expect(unscheduleSpeaker).toHaveBeenCalledWith("2026-02-22");
@@ -672,6 +685,7 @@ describe("Landing", () => {
     });
 
     it("renders datalist with speaker name options when form is shown", async () => {
+      const user = userEvent.setup();
       getSpeakerNames.mockResolvedValue(["Alice", "Bob", "Zara"]);
       getUpcomingMeeting.mockResolvedValue(speakerMeetingNoSpeaker);
       renderLanding();
@@ -682,7 +696,9 @@ describe("Landing", () => {
         ).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "Schedule Speaker" }));
+      await user.click(
+        screen.getByRole("button", { name: "Schedule Speaker" }),
+      );
 
       await waitFor(() => {
         expect(getSpeakerNames).toHaveBeenCalled();
@@ -700,6 +716,7 @@ describe("Landing", () => {
     });
 
     it("shows toast on remove failure", async () => {
+      const user = userEvent.setup();
       getUpcomingMeeting.mockResolvedValue(speakerMeeting);
       unscheduleSpeaker.mockRejectedValue(new Error("Remove failed"));
       renderLanding();
@@ -710,7 +727,7 @@ describe("Landing", () => {
         ).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "Remove speaker" }));
+      await user.click(screen.getByRole("button", { name: "Remove speaker" }));
 
       await waitFor(() => {
         expect(screen.getByText("Remove failed")).toBeInTheDocument();
@@ -746,6 +763,7 @@ describe("Landing", () => {
     });
 
     it("calls updateAttendance when saving attendance", async () => {
+      const user = userEvent.setup();
       getUpcomingMeeting.mockResolvedValue(baseMeeting);
       updateAttendance.mockResolvedValue({});
       renderLanding();
@@ -756,13 +774,11 @@ describe("Landing", () => {
         ).toBeInTheDocument();
       });
 
-      fireEvent.click(
+      await user.click(
         screen.getByRole("button", { name: "Record Attendance" }),
       );
-      fireEvent.change(screen.getByPlaceholderText("Attendance"), {
-        target: { value: "20" },
-      });
-      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+      await user.type(screen.getByPlaceholderText("Attendance"), "20");
+      await user.click(screen.getByRole("button", { name: "Save" }));
 
       await waitFor(() => {
         expect(updateAttendance).toHaveBeenCalledWith("2026-02-22", 20);
@@ -770,6 +786,7 @@ describe("Landing", () => {
     });
 
     it("shows error toast for invalid attendance input", async () => {
+      const user = userEvent.setup();
       getUpcomingMeeting.mockResolvedValue(baseMeeting);
       renderLanding();
 
@@ -779,18 +796,17 @@ describe("Landing", () => {
         ).toBeInTheDocument();
       });
 
-      fireEvent.click(
+      await user.click(
         screen.getByRole("button", { name: "Record Attendance" }),
       );
-      fireEvent.change(screen.getByPlaceholderText("Attendance"), {
-        target: { value: "-5" },
-      });
-      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+      await user.type(screen.getByPlaceholderText("Attendance"), "-5");
+      await user.click(screen.getByRole("button", { name: "Save" }));
 
       expect(updateAttendance).not.toHaveBeenCalled();
     });
 
     it("clears attendance by saving empty input", async () => {
+      const user = userEvent.setup();
       getUpcomingMeeting.mockResolvedValue({
         ...baseMeeting,
         attendance_count: 15,
@@ -802,11 +818,9 @@ describe("Landing", () => {
         expect(screen.getByText("Attendance: 15")).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "Edit attendance" }));
-      fireEvent.change(screen.getByPlaceholderText("Attendance"), {
-        target: { value: "" },
-      });
-      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+      await user.click(screen.getByRole("button", { name: "Edit attendance" }));
+      await user.clear(screen.getByPlaceholderText("Attendance"));
+      await user.click(screen.getByRole("button", { name: "Save" }));
 
       await waitFor(() => {
         expect(updateAttendance).toHaveBeenCalledWith("2026-02-22", null);
@@ -845,6 +859,7 @@ describe("Landing", () => {
     });
 
     it("opens inline form when Assign Speaker is clicked", async () => {
+      const user = userEvent.setup();
       getUpcomingMeeting.mockResolvedValue(baseMeeting);
       renderLanding();
 
@@ -854,12 +869,13 @@ describe("Landing", () => {
         ).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "Assign Speaker" }));
+      await user.click(screen.getByRole("button", { name: "Assign Speaker" }));
 
       expect(screen.getByPlaceholderText("Speaker name")).toBeInTheDocument();
     });
 
     it("calls scheduleSpeaker on form submit", async () => {
+      const user = userEvent.setup();
       getUpcomingMeeting.mockResolvedValue(baseMeeting);
       scheduleSpeaker.mockResolvedValue({});
       renderLanding();
@@ -870,11 +886,9 @@ describe("Landing", () => {
         ).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "Assign Speaker" }));
-      fireEvent.change(screen.getByPlaceholderText("Speaker name"), {
-        target: { value: "Bob" },
-      });
-      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+      await user.click(screen.getByRole("button", { name: "Assign Speaker" }));
+      await user.type(screen.getByPlaceholderText("Speaker name"), "Bob");
+      await user.click(screen.getByRole("button", { name: "Save" }));
 
       await waitFor(() => {
         expect(scheduleSpeaker).toHaveBeenCalledWith("2026-03-29", "Bob");
@@ -895,6 +909,7 @@ describe("Landing", () => {
 
   describe("error handling", () => {
     it("shows toast when cancel fails", async () => {
+      const user = userEvent.setup();
       getUpcomingMeeting.mockResolvedValue(baseMeeting);
       cancelMeeting.mockRejectedValue(new Error("Cancel failed"));
       renderLanding();
@@ -905,7 +920,7 @@ describe("Landing", () => {
         ).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "Cancel Meeting" }));
+      await user.click(screen.getByRole("button", { name: "Cancel Meeting" }));
 
       await waitFor(() => {
         expect(screen.getByText("Cancel failed")).toBeInTheDocument();
@@ -913,6 +928,7 @@ describe("Landing", () => {
     });
 
     it("shows toast when restore fails", async () => {
+      const user = userEvent.setup();
       getUpcomingMeeting.mockResolvedValue(cancelledMeeting);
       cancelMeeting.mockRejectedValue(new Error("Restore failed"));
       renderLanding();
@@ -923,7 +939,7 @@ describe("Landing", () => {
         ).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "Restore Meeting" }));
+      await user.click(screen.getByRole("button", { name: "Restore Meeting" }));
 
       await waitFor(() => {
         expect(screen.getByText("Restore failed")).toBeInTheDocument();

--- a/frontend/tests/Log.test.tsx
+++ b/frontend/tests/Log.test.tsx
@@ -7,6 +7,7 @@ import {
   waitFor,
   act,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Log } from "../src/pages/Log";
 import { ToastProvider } from "../src/contexts/ToastContext";
 import type { MeetingLogEntry } from "../src/types/index";
@@ -162,6 +163,7 @@ describe("Log", () => {
 
   describe("filtering", () => {
     it("filters by format type", async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       getMeetingLog.mockResolvedValue(mockEntries);
       renderLog();
 
@@ -169,9 +171,7 @@ describe("Log", () => {
         expect(screen.getByText("Mindfulness")).toBeInTheDocument();
       });
 
-      fireEvent.change(screen.getByLabelText("Format"), {
-        target: { value: "Speaker" },
-      });
+      await user.selectOptions(screen.getByLabelText("Format"), "Speaker");
 
       expect(screen.getByText("Jane Doe")).toBeInTheDocument();
       expect(screen.queryByText("Mindfulness")).not.toBeInTheDocument();
@@ -194,6 +194,7 @@ describe("Log", () => {
     });
 
     it("filters by search text with debounce", async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       getMeetingLog.mockResolvedValue(mockEntries);
       renderLog();
 
@@ -201,9 +202,7 @@ describe("Log", () => {
         expect(screen.getByText("Mindfulness")).toBeInTheDocument();
       });
 
-      fireEvent.change(screen.getByPlaceholderText("Search..."), {
-        target: { value: "Jane" },
-      });
+      await user.type(screen.getByPlaceholderText("Search..."), "Jane");
 
       // Before debounce, all entries still visible
       expect(screen.getByText("Mindfulness")).toBeInTheDocument();
@@ -233,6 +232,7 @@ describe("Log", () => {
     });
 
     it("shows clear filters button when filters active", async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       getMeetingLog.mockResolvedValue(mockEntries);
       renderLog();
 
@@ -240,9 +240,7 @@ describe("Log", () => {
         expect(screen.getByText("Mindfulness")).toBeInTheDocument();
       });
 
-      fireEvent.change(screen.getByLabelText("Format"), {
-        target: { value: "Speaker" },
-      });
+      await user.selectOptions(screen.getByLabelText("Format"), "Speaker");
 
       expect(screen.getByText("Clear Filters")).toBeInTheDocument();
     });
@@ -291,6 +289,7 @@ describe("Log", () => {
     });
 
     it("clears all filters on clear button click", async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       getMeetingLog.mockResolvedValue(mockEntries);
       renderLog();
 
@@ -298,13 +297,11 @@ describe("Log", () => {
         expect(screen.getByText("Mindfulness")).toBeInTheDocument();
       });
 
-      fireEvent.change(screen.getByLabelText("Format"), {
-        target: { value: "Speaker" },
-      });
+      await user.selectOptions(screen.getByLabelText("Format"), "Speaker");
 
       expect(screen.queryByText("Mindfulness")).not.toBeInTheDocument();
 
-      fireEvent.click(screen.getByText("Clear Filters"));
+      await user.click(screen.getByText("Clear Filters"));
 
       expect(screen.getByText("Mindfulness")).toBeInTheDocument();
       expect(screen.getByText("Jane Doe")).toBeInTheDocument();
@@ -325,6 +322,7 @@ describe("Log", () => {
     });
 
     it("clicking Edit shows inline form with current values", async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       getMeetingLog.mockResolvedValue(mockEntries);
       renderLog();
 
@@ -333,7 +331,7 @@ describe("Log", () => {
       });
 
       const editButtons = screen.getAllByText("Edit");
-      fireEvent.click(editButtons[1]); // Speaker entry
+      await user.click(editButtons[1]); // Speaker entry
 
       expect(screen.getByLabelText("Speaker Name")).toHaveValue("Jane Doe");
       expect(screen.getByLabelText("Notes")).toHaveValue("");
@@ -341,6 +339,7 @@ describe("Log", () => {
     });
 
     it("saving calls updateMeetingLogEntry and updates the row", async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       getMeetingLog.mockResolvedValue(mockEntries);
       const updatedEntry = {
         ...mockEntries[1],
@@ -354,13 +353,12 @@ describe("Log", () => {
       });
 
       const editButtons = screen.getAllByText("Edit");
-      fireEvent.click(editButtons[1]);
+      await user.click(editButtons[1]);
 
-      fireEvent.change(screen.getByLabelText("Speaker Name"), {
-        target: { value: "John Smith" },
-      });
+      await user.clear(screen.getByLabelText("Speaker Name"));
+      await user.type(screen.getByLabelText("Speaker Name"), "John Smith");
 
-      fireEvent.click(screen.getByText("Save"));
+      await user.click(screen.getByText("Save"));
 
       await waitFor(() => {
         expect(updateMeetingLogEntry).toHaveBeenCalledWith(2, {
@@ -376,6 +374,7 @@ describe("Log", () => {
     });
 
     it("clicking Cancel closes the form without saving", async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       getMeetingLog.mockResolvedValue(mockEntries);
       renderLog();
 
@@ -384,11 +383,11 @@ describe("Log", () => {
       });
 
       const editButtons = screen.getAllByText("Edit");
-      fireEvent.click(editButtons[1]);
+      await user.click(editButtons[1]);
 
       expect(screen.getByLabelText("Speaker Name")).toBeInTheDocument();
 
-      fireEvent.click(screen.getByText("Cancel"));
+      await user.click(screen.getByText("Cancel"));
 
       expect(screen.queryByLabelText("Speaker Name")).not.toBeInTheDocument();
       expect(updateMeetingLogEntry).not.toHaveBeenCalled();

--- a/frontend/tests/Login.test.tsx
+++ b/frontend/tests/Login.test.tsx
@@ -1,6 +1,7 @@
 /** Tests for Login page component. */
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { ToastProvider } from "../src/contexts/ToastContext";
 import { Login } from "../src/pages/Login";
@@ -39,9 +40,10 @@ describe("Login", () => {
     expect(screen.getByLabelText("Password")).toBeInTheDocument();
   });
 
-  it("toggles to register mode", () => {
+  it("toggles to register mode", async () => {
+    const user = userEvent.setup();
     renderLogin();
-    fireEvent.click(screen.getByText("Need an account? Register"));
+    await user.click(screen.getByText("Need an account? Register"));
     expect(
       screen.getByRole("heading", { name: "Create Account" }),
     ).toBeInTheDocument();
@@ -57,15 +59,12 @@ describe("Login", () => {
     expect(screen.getByText("Please wait...")).toBeDisabled();
   });
 
-  it("calls onLogin when form is submitted in login mode", () => {
+  it("calls onLogin when form is submitted in login mode", async () => {
+    const user = userEvent.setup();
     renderLogin();
-    fireEvent.change(screen.getByLabelText("Username"), {
-      target: { value: "testuser" },
-    });
-    fireEvent.change(screen.getByLabelText("Password"), {
-      target: { value: "testpass" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Log In" }));
+    await user.type(screen.getByLabelText("Username"), "testuser");
+    await user.type(screen.getByLabelText("Password"), "testpass");
+    await user.click(screen.getByRole("button", { name: "Log In" }));
     expect(mockLogin).toHaveBeenCalledWith("testuser", "testpass");
   });
 

--- a/frontend/tests/Settings.test.tsx
+++ b/frontend/tests/Settings.test.tsx
@@ -1,6 +1,7 @@
 /** Tests for Settings page section navigation and sticky save bar. */
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ToastProvider } from "../src/contexts/ToastContext";
 import { Settings } from "../src/pages/Settings";
 import type {
@@ -124,20 +125,21 @@ describe("Settings", () => {
   });
 
   it("shows sticky bar when name is changed", async () => {
+    const user = userEvent.setup();
     renderSettings();
 
     await waitFor(() => {
       expect(screen.getByDisplayValue("Test Meeting")).toBeInTheDocument();
     });
 
-    fireEvent.change(screen.getByDisplayValue("Test Meeting"), {
-      target: { value: "New Name" },
-    });
+    await user.clear(screen.getByDisplayValue("Test Meeting"));
+    await user.type(screen.getByLabelText("Group Name"), "New Name");
 
     expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
   });
 
   it("hides sticky bar after save", async () => {
+    const user = userEvent.setup();
     (api.updateSettings as jest.Mock).mockResolvedValue({
       ...mockSettings,
       name: "New Name",
@@ -148,13 +150,12 @@ describe("Settings", () => {
       expect(screen.getByDisplayValue("Test Meeting")).toBeInTheDocument();
     });
 
-    fireEvent.change(screen.getByDisplayValue("Test Meeting"), {
-      target: { value: "New Name" },
-    });
+    await user.clear(screen.getByDisplayValue("Test Meeting"));
+    await user.type(screen.getByLabelText("Group Name"), "New Name");
 
     expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
 
     await waitFor(() => {
       expect(
@@ -164,19 +165,19 @@ describe("Settings", () => {
   });
 
   it("reverts changes on discard", async () => {
+    const user = userEvent.setup();
     renderSettings();
 
     await waitFor(() => {
       expect(screen.getByDisplayValue("Test Meeting")).toBeInTheDocument();
     });
 
-    fireEvent.change(screen.getByDisplayValue("Test Meeting"), {
-      target: { value: "Changed Name" },
-    });
+    await user.clear(screen.getByDisplayValue("Test Meeting"));
+    await user.type(screen.getByLabelText("Group Name"), "Changed Name");
 
     expect(screen.getByDisplayValue("Changed Name")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Discard" }));
+    await user.click(screen.getByRole("button", { name: "Discard" }));
 
     expect(screen.getByDisplayValue("Test Meeting")).toBeInTheDocument();
     expect(
@@ -193,21 +194,21 @@ describe("Settings", () => {
   });
 
   it("shows sticky bar when meeting day is changed", async () => {
+    const user = userEvent.setup();
     renderSettings();
 
     await waitFor(() => {
       expect(screen.getByDisplayValue("Sunday")).toBeInTheDocument();
     });
 
-    fireEvent.change(screen.getByDisplayValue("Sunday"), {
-      target: { value: "0" },
-    });
+    await user.selectOptions(screen.getByDisplayValue("Sunday"), "0");
 
     expect(screen.getByDisplayValue("Monday")).toBeInTheDocument();
     expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
   });
 
   it("includes meeting_day in updateSettings call when saving", async () => {
+    const user = userEvent.setup();
     (api.updateSettings as jest.Mock).mockResolvedValue({
       ...mockSettings,
       meeting_day: 1,
@@ -218,11 +219,9 @@ describe("Settings", () => {
       expect(screen.getByDisplayValue("Sunday")).toBeInTheDocument();
     });
 
-    fireEvent.change(screen.getByDisplayValue("Sunday"), {
-      target: { value: "1" },
-    });
+    await user.selectOptions(screen.getByDisplayValue("Sunday"), "1");
 
-    fireEvent.click(screen.getByText("Save Changes"));
+    await user.click(screen.getByText("Save Changes"));
 
     await waitFor(() =>
       expect(api.updateSettings).toHaveBeenCalledWith(
@@ -261,6 +260,7 @@ describe("Settings", () => {
   });
 
   it("shows toast on save error", async () => {
+    const user = userEvent.setup();
     (api.updateSettings as jest.Mock).mockRejectedValue(
       new Error("Save failed"),
     );
@@ -270,11 +270,10 @@ describe("Settings", () => {
       expect(screen.getByDisplayValue("Test Meeting")).toBeInTheDocument();
     });
 
-    fireEvent.change(screen.getByDisplayValue("Test Meeting"), {
-      target: { value: "New Name" },
-    });
+    await user.clear(screen.getByDisplayValue("Test Meeting"));
+    await user.type(screen.getByLabelText("Group Name"), "New Name");
 
-    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
 
     await waitFor(() => {
       expect(screen.getByText("Save failed")).toBeInTheDocument();
@@ -340,6 +339,7 @@ describe("Settings", () => {
   });
 
   it("enables Add Selected button only when chapters are checked", async () => {
+    const user = userEvent.setup();
     const planWithChapters: ReadingPlanStatus = {
       ...mockPlan,
       total_chapters: 2,
@@ -365,13 +365,14 @@ describe("Settings", () => {
     expect(screen.getByText(/Add Selected/)).toBeDisabled();
 
     // Check a chapter
-    fireEvent.click(screen.getByLabelText(/Preface/));
+    await user.click(screen.getByLabelText(/Preface/));
 
     // Button should now be enabled
     expect(screen.getByText(/Add Selected \(1\)/)).toBeEnabled();
   });
 
   it("calls addChapterToPlan for each selected chapter", async () => {
+    const user = userEvent.setup();
     const planWithChapters: ReadingPlanStatus = {
       ...mockPlan,
       total_chapters: 2,
@@ -403,10 +404,10 @@ describe("Settings", () => {
     });
 
     // Select both chapters
-    fireEvent.click(screen.getByLabelText(/Preface/));
-    fireEvent.click(screen.getByLabelText(/Introduction/));
+    await user.click(screen.getByLabelText(/Preface/));
+    await user.click(screen.getByLabelText(/Introduction/));
 
-    fireEvent.click(screen.getByText(/Add Selected \(2\)/));
+    await user.click(screen.getByText(/Add Selected \(2\)/));
 
     await waitFor(() => {
       expect(api.addChapterToPlan).toHaveBeenCalledTimes(2);
@@ -551,6 +552,7 @@ describe("Settings", () => {
   });
 
   it("shows inline confirmation for reshuffle", async () => {
+    const user = userEvent.setup();
     renderSettings();
 
     await waitFor(() => {
@@ -559,7 +561,7 @@ describe("Settings", () => {
       ).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Reshuffle Deck" }));
+    await user.click(screen.getByRole("button", { name: "Reshuffle Deck" }));
 
     expect(
       screen.getByText("Reshuffle the deck? All drawn topics will return."),
@@ -571,6 +573,7 @@ describe("Settings", () => {
   });
 
   it("cancels reshuffle on cancel click", async () => {
+    const user = userEvent.setup();
     renderSettings();
 
     await waitFor(() => {
@@ -579,8 +582,8 @@ describe("Settings", () => {
       ).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Reshuffle Deck" }));
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await user.click(screen.getByRole("button", { name: "Reshuffle Deck" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
 
     expect(
       screen.getByRole("button", { name: "Reshuffle Deck" }),
@@ -591,6 +594,7 @@ describe("Settings", () => {
   });
 
   it("executes reshuffle on confirm", async () => {
+    const user = userEvent.setup();
     (api.reshuffleTopics as jest.Mock).mockResolvedValue(undefined);
     (api.getTopics as jest.Mock).mockResolvedValue(mockTopics);
     renderSettings();
@@ -601,8 +605,8 @@ describe("Settings", () => {
       ).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Reshuffle Deck" }));
-    fireEvent.click(screen.getByRole("button", { name: "Confirm Reshuffle" }));
+    await user.click(screen.getByRole("button", { name: "Reshuffle Deck" }));
+    await user.click(screen.getByRole("button", { name: "Confirm Reshuffle" }));
 
     await waitFor(() => {
       expect(api.reshuffleTopics).toHaveBeenCalledTimes(1);
@@ -610,6 +614,7 @@ describe("Settings", () => {
   });
 
   it("shows inline confirmation when deleting a topic", async () => {
+    const user = userEvent.setup();
     renderSettings();
 
     await waitFor(() => {
@@ -618,7 +623,7 @@ describe("Settings", () => {
 
     const topicItem = screen.getByText("Topic 1").closest("li")!;
     const removeBtn = topicItem.querySelector("button")!;
-    fireEvent.click(removeBtn);
+    await user.click(removeBtn);
 
     expect(
       screen.getByRole("button", { name: "Confirm Remove" }),
@@ -626,6 +631,7 @@ describe("Settings", () => {
   });
 
   it("cancels topic deletion on cancel click", async () => {
+    const user = userEvent.setup();
     renderSettings();
 
     await waitFor(() => {
@@ -634,9 +640,9 @@ describe("Settings", () => {
 
     const topicItem = screen.getByText("Topic 1").closest("li")!;
     const removeBtn = topicItem.querySelector("button")!;
-    fireEvent.click(removeBtn);
+    await user.click(removeBtn);
 
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
 
     expect(
       screen.queryByRole("button", { name: "Confirm Remove" }),
@@ -644,6 +650,7 @@ describe("Settings", () => {
   });
 
   it("executes topic deletion on confirm", async () => {
+    const user = userEvent.setup();
     (api.deleteTopic as jest.Mock).mockResolvedValue(undefined);
     renderSettings();
 
@@ -656,9 +663,9 @@ describe("Settings", () => {
 
     const topicItem = screen.getByText("Topic 1").closest("li")!;
     const removeBtn = topicItem.querySelector("button")!;
-    fireEvent.click(removeBtn);
+    await user.click(removeBtn);
 
-    fireEvent.click(screen.getByRole("button", { name: "Confirm Remove" }));
+    await user.click(screen.getByRole("button", { name: "Confirm Remove" }));
 
     await waitFor(() => {
       expect(api.deleteTopic).toHaveBeenCalledWith(1);
@@ -666,6 +673,7 @@ describe("Settings", () => {
   });
 
   it("shows inline confirmation when deleting an assignment", async () => {
+    const user = userEvent.setup();
     const planWithAssignment: ReadingPlanStatus = {
       ...mockPlan,
       total_chapters: 3,
@@ -698,7 +706,7 @@ describe("Settings", () => {
       expect(screen.getByText(/Preface/)).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
 
     expect(
       screen.getByRole("button", { name: "Confirm Delete" }),
@@ -707,6 +715,7 @@ describe("Settings", () => {
   });
 
   it("cancels assignment deletion on cancel click", async () => {
+    const user = userEvent.setup();
     const planWithAssignment: ReadingPlanStatus = {
       ...mockPlan,
       total_chapters: 3,
@@ -739,8 +748,8 @@ describe("Settings", () => {
       expect(screen.getByText(/Preface/)).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
 
     expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
     expect(
@@ -749,6 +758,7 @@ describe("Settings", () => {
   });
 
   it("executes assignment deletion on confirm", async () => {
+    const user = userEvent.setup();
     const planWithAssignment: ReadingPlanStatus = {
       ...mockPlan,
       total_chapters: 3,
@@ -784,8 +794,8 @@ describe("Settings", () => {
       expect(screen.getByText(/Preface/)).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
-    fireEvent.click(screen.getByRole("button", { name: "Confirm Delete" }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    await user.click(screen.getByRole("button", { name: "Confirm Delete" }));
 
     await waitFor(() => {
       expect(api.deleteAssignment).toHaveBeenCalledWith(10);

--- a/frontend/tests/Toast.test.tsx
+++ b/frontend/tests/Toast.test.tsx
@@ -1,6 +1,7 @@
 /** Tests for Toast component and ToastContainer. */
 
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Toast, ToastContainer } from "../src/components/Toast";
 import type { ToastData } from "../src/components/Toast";
 
@@ -46,9 +47,10 @@ describe("Toast", () => {
     expect(screen.getByRole("status")).toBeInTheDocument();
   });
 
-  it("calls onDismiss when close button is clicked", () => {
+  it("calls onDismiss when close button is clicked", async () => {
+    const user = userEvent.setup();
     render(<Toast toast={infoToast} onDismiss={mockDismiss} />);
-    fireEvent.click(screen.getByLabelText("Dismiss notification"));
+    await user.click(screen.getByLabelText("Dismiss notification"));
     expect(mockDismiss).toHaveBeenCalledWith("t1");
   });
 });


### PR DESCRIPTION
## Summary
- Migrates all frontend tests from `fireEvent` to `@testing-library/user-event`
- `fireEvent.click` → `await user.click()`
- `fireEvent.change` → `await user.clear()` + `await user.type()` or `await user.selectOptions()`
- More realistic user interaction simulation improves test reliability

Closes #48

## Test plan
- [ ] Frontend: 187 tests passing, 4/4 checks green
- [ ] All existing test behaviors preserved
- [ ] No backend changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)