### PR TITLE
feat: polish printable export with RD brand styling

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,4 +41,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/backend/app/routers/export.py
+++ b/backend/app/routers/export.py
@@ -34,9 +34,12 @@ def export_csv(
 def export_printable(
     start_date: date | None = Query(default=None),
     end_date: date | None = Query(default=None),
+    blank_rows: int = Query(default=10, ge=0, le=52),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> PlainTextResponse:
     """Export a printable HTML log template."""
-    html = generate_printable_export(db, current_user.group, start_date, end_date)
+    html = generate_printable_export(
+        db, current_user.group, start_date, end_date, blank_rows=blank_rows
+    )
     return PlainTextResponse(content=html, media_type="text/html")

--- a/backend/app/services.py
+++ b/backend/app/services.py
@@ -823,57 +823,148 @@ def generate_csv_export(
     return "\n".join(lines) + "\n"
 
 
+def _format_date_range(start_date: date | None, end_date: date | None) -> str:
+    """Format date range for display in the printable export header."""
+    if start_date and end_date:
+        start_str = start_date.strftime("%B %Y")
+        end_str = end_date.strftime("%B %Y")
+        if start_str == end_str:
+            return start_str
+        return f"{start_str} &mdash; {end_str}"
+    if start_date:
+        return f"From {start_date.strftime('%B %Y')}"
+    if end_date:
+        return f"Through {end_date.strftime('%B %Y')}"
+    return ""
+
+
+def _get_entry_content(db: Session, group: Group, entry: MeetingLog) -> str:
+    """Extract display content from a meeting log entry based on format type."""
+    if entry.format_type == "Speaker":
+        return entry.speaker_name or "_______________"
+    if entry.format_type == "Topic" and entry.topic_id:
+        topic = db.query(Topic).filter(Topic.id == entry.topic_id).first()
+        return topic.name if topic else ""
+    if entry.format_type == "Book Study":
+        summary = _get_book_chapter_summary(db, group, entry.meeting_date)
+        return summary or ""
+    return ""
+
+
+def _build_export_rows(
+    db: Session,
+    group: Group,
+    entries: list[MeetingLog],
+    blank_rows: int,
+) -> str:
+    """Build HTML table rows for the printable export."""
+    rows = []
+    for entry in entries:
+        content = _get_entry_content(db, group, entry)
+        attendance = (
+            str(entry.attendance_count) if entry.attendance_count is not None else ""
+        )
+        rows.append(
+            f"<tr><td>{entry.meeting_date}</td>"
+            f"<td>{entry.format_type}</td>"
+            f"<td>{content}</td>"
+            f"<td>{attendance}</td></tr>"
+        )
+
+    for _ in range(blank_rows):
+        rows.append(
+            '<tr class="blank-row">' "<td>&nbsp;</td><td></td><td></td><td></td></tr>"
+        )
+
+    return "\n".join(rows)
+
+
 def generate_printable_export(
     db: Session,
     group: Group,
     start_date: date | None = None,
     end_date: date | None = None,
+    blank_rows: int = 10,
 ) -> str:
-    """Generate a printable HTML meeting log."""
+    """Generate a printable HTML meeting log with RD brand styling."""
     entries = _query_meeting_log(
         db, group, start_date, end_date, exclude_cancelled=True
     )
 
-    rows = []
-    for entry in entries:
-        content = ""
-        if entry.format_type == "Speaker":
-            content = entry.speaker_name or "_______________"
-        elif entry.format_type == "Topic" and entry.topic_id:
-            topic = db.query(Topic).filter(Topic.id == entry.topic_id).first()
-            content = topic.name if topic else ""
-        rows.append(
-            f"<tr><td>{entry.meeting_date}</td>"
-            f"<td>{entry.format_type}</td>"
-            f"<td>{content}</td></tr>"
-        )
+    table_rows = _build_export_rows(db, group, entries, blank_rows)
 
-    # Add blank rows for future weeks
-    for _ in range(10):
-        rows.append("<tr><td>&nbsp;</td><td></td><td></td></tr>")
+    date_range = _format_date_range(start_date, end_date)
+    date_range_html = f'<p class="date-range">{date_range}</p>' if date_range else ""
 
-    table_rows = "\n".join(rows)
+    font_url = (
+        "https://fonts.googleapis.com" "/css2?family=Lato:wght@400;700&display=swap"
+    )
 
     return f"""<!DOCTYPE html>
 <html>
 <head>
+<meta charset="utf-8">
 <title>Meeting Log - {group.name}</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="{font_url}" rel="stylesheet">
 <style>
-body {{ font-family: serif; max-width: 700px; margin: 2em auto; }}
-h1 {{ text-align: center; border-bottom: 2px solid #333; padding-bottom: 0.5em; }}
-table {{ width: 100%; border-collapse: collapse; margin-top: 1em; }}
-th, td {{ border: 1px solid #999; padding: 6px 10px; text-align: left; }}
-th {{ background: #eee; }}
-@media print {{ body {{ margin: 0; }} }}
+body {{
+  font-family: 'Lato', sans-serif;
+  max-width: 750px;
+  margin: 2em auto;
+  color: #333;
+}}
+h1 {{
+  text-align: center;
+  color: #1b6b6d;
+  margin-bottom: 0.2em;
+  font-weight: 700;
+}}
+.header-rule {{
+  border: none;
+  border-top: 3px solid #c4922a;
+  margin: 0 auto 0.5em auto;
+  width: 60%;
+}}
+.date-range {{
+  text-align: center;
+  color: #666;
+  font-size: 0.95em;
+  margin-top: 0;
+}}
+table {{ width: 100%; border-collapse: collapse; margin-top: 1.2em; }}
+th, td {{ border: 1px solid #ccc; padding: 6px 10px; text-align: left; }}
+th {{
+  background: #1b6b6d;
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.9em;
+}}
+tr:nth-child(even) {{ background: #f7f7f7; }}
+.blank-row td {{ height: 1.6em; }}
+.footer {{
+  text-align: center;
+  color: #aaa;
+  font-size: 0.8em;
+  margin-top: 2em;
+}}
+@media print {{
+  body {{ margin: 0; }}
+  .footer {{ color: #ccc; }}
+}}
 </style>
 </head>
 <body>
-<h1>{group.name} &mdash; Meeting Log</h1>
+<h1>{group.name}</h1>
+<hr class="header-rule">
+{date_range_html}
 <table>
-<thead><tr><th>Date</th><th>Format</th><th>Content</th></tr></thead>
+<thead><tr><th>Date</th><th>Format</th><th>Content</th><th>Attendance</th></tr></thead>
 <tbody>
 {table_rows}
 </tbody>
 </table>
+<p class="footer">Generated from RD Log</p>
 </body>
 </html>"""

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -775,3 +775,28 @@ class TestExportEndpoints:
         assert response.status_code == 200
         lines = response.text.strip().split("\n")
         assert len(lines) == 3  # header + 2 entries
+
+    def test_printable_blank_rows_param(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Printable export respects blank_rows query param."""
+        response = client.get(
+            "/export/printable?blank_rows=3",
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        assert response.text.count('class="blank-row"') == 3
+
+    def test_printable_blank_rows_validation(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Printable export rejects blank_rows outside 0-52 range."""
+        response = client.get(
+            "/export/printable?blank_rows=100",
+            headers=auth_headers,
+        )
+        assert response.status_code == 422

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -20,6 +20,7 @@ from app.services import (
     draw_random_topic,
     finalize_current_assignment,
     generate_csv_export,
+    generate_printable_export,
     get_deck_stats,
     get_format_for_date,
     get_next_meeting_date,
@@ -662,7 +663,9 @@ class TestUpcomingMeeting:
         from app.services import _get_book_chapter_summary
 
         summary = _get_book_chapter_summary(
-            db_session, group, date(2025, 1, 19)  # 3rd week = Book Study
+            db_session,
+            group,
+            date(2025, 1, 19),  # 3rd week = Book Study
         )
         assert summary is not None
         assert "Preface" in summary
@@ -896,8 +899,6 @@ class TestExport:
         )
         db_session.flush()
 
-        from app.services import generate_printable_export
-
         html = generate_printable_export(db_session, group)
         assert "<!DOCTYPE html>" in html
         assert "Test Meeting" in html
@@ -906,8 +907,132 @@ class TestExport:
 
     def test_printable_export_empty(self, db_session: Session) -> None:
         group = _create_group(db_session)
-        from app.services import generate_printable_export
 
         html = generate_printable_export(db_session, group)
         assert "<!DOCTYPE html>" in html
         assert "Test Meeting" in html
+
+    def test_printable_export_uses_lato_font(self, db_session: Session) -> None:
+        group = _create_group(db_session)
+
+        html = generate_printable_export(db_session, group)
+        assert "fonts.googleapis.com" in html
+        assert "Lato" in html
+
+    def test_printable_export_blank_rows_default(self, db_session: Session) -> None:
+        group = _create_group(db_session)
+
+        html = generate_printable_export(db_session, group)
+        # Default is 10 blank rows; each has class="blank-row"
+        assert html.count('class="blank-row"') == 10
+
+    def test_printable_export_blank_rows_custom(self, db_session: Session) -> None:
+        group = _create_group(db_session)
+
+        html = generate_printable_export(db_session, group, blank_rows=5)
+        assert html.count('class="blank-row"') == 5
+
+    def test_printable_export_blank_rows_zero(self, db_session: Session) -> None:
+        group = _create_group(db_session)
+
+        html = generate_printable_export(db_session, group, blank_rows=0)
+        assert 'class="blank-row"' not in html
+
+    def test_printable_export_date_range_header(self, db_session: Session) -> None:
+        group = _create_group(db_session)
+        db_session.add(
+            MeetingLog(
+                group_id=group.id,
+                meeting_date=date(2025, 1, 5),
+                format_type="Speaker",
+            )
+        )
+        db_session.flush()
+
+        html = generate_printable_export(
+            db_session,
+            group,
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 3, 31),
+        )
+        assert "January 2025" in html
+        assert "March 2025" in html
+
+    def test_printable_export_rd_brand_colors(self, db_session: Session) -> None:
+        group = _create_group(db_session)
+
+        html = generate_printable_export(db_session, group)
+        assert "#1b6b6d" in html
+        assert "#c4922a" in html
+
+    def test_printable_export_footer(self, db_session: Session) -> None:
+        group = _create_group(db_session)
+
+        html = generate_printable_export(db_session, group)
+        assert "Generated from RD Log" in html
+
+    def test_printable_export_shows_attendance(self, db_session: Session) -> None:
+        group = _create_group(db_session)
+        db_session.add(
+            MeetingLog(
+                group_id=group.id,
+                meeting_date=date(2025, 1, 5),
+                format_type="Speaker",
+                speaker_name="Clare",
+                attendance_count=15,
+            )
+        )
+        db_session.flush()
+
+        html = generate_printable_export(db_session, group)
+        assert "15" in html
+        assert "Attendance" in html
+
+    def test_printable_export_shows_topic(self, db_session: Session) -> None:
+        group = _create_group(db_session)
+        topic = Topic(group_id=group.id, name="Letting Go", is_active=True)
+        db_session.add(topic)
+        db_session.flush()
+        db_session.add(
+            MeetingLog(
+                group_id=group.id,
+                meeting_date=date(2025, 1, 12),
+                format_type="Topic",
+                topic_id=topic.id,
+            )
+        )
+        db_session.flush()
+
+        html = generate_printable_export(db_session, group)
+        assert "Letting Go" in html
+
+    def test_printable_export_shows_book_study(self, db_session: Session) -> None:
+        group = _create_group(db_session)
+        ch = BookChapter(
+            group_id=group.id,
+            order=1,
+            start_page="1",
+            end_page="20",
+            title="Introduction",
+        )
+        db_session.add(ch)
+        db_session.flush()
+        ra = ReadingAssignment(
+            group_id=group.id,
+            assignment_order=1,
+            chapters_json=f"[{ch.id}]",
+            meeting_date=date(2025, 1, 19),
+        )
+        db_session.add(ra)
+        db_session.flush()
+        db_session.add(
+            MeetingLog(
+                group_id=group.id,
+                meeting_date=date(2025, 1, 19),
+                format_type="Book Study",
+            )
+        )
+        db_session.flush()
+
+        html = generate_printable_export(db_session, group)
+        assert "Introduction" in html


### PR DESCRIPTION
## Summary
- Redesigns printable export HTML with RD brand styling (Lato font, teal headers, saffron accents)
- Adds attendance column to printable view
- Adds configurable `blank_rows` query parameter (default 10, max 52) for sign-in sheets
- Adds date range display in header
- Extracts `_get_entry_content()` and `_build_export_rows()` helpers for maintainability

Closes #39

## Test plan
- [ ] Backend: 135 tests passing, 91.86% coverage
- [ ] Frontend: 187 tests passing, 4/4 checks green
- [ ] Verify printable export renders with RD brand styling
- [ ] Verify blank_rows parameter works (0, 10, 52)

🤖 Generated with [Claude Code](https://claude.com/claude-code)