### PR TITLE
fix: keep meeting visible on landing page until the day after it is held

### DIFF
--- a/backend/app/services.py
+++ b/backend/app/services.py
@@ -905,8 +905,14 @@ def get_speaker_banners(db: Session, group: Group) -> list[str]:
 
 
 def get_upcoming_meeting_data(db: Session, group: Group) -> dict:
-    """Build the full upcoming meeting response."""
-    meeting_date = get_next_meeting_date(group)
+    """Build the full upcoming meeting response.
+
+    Uses a 1-day grace period so the meeting remains visible on the landing
+    page until the day after it is held.
+    """
+    meeting_date = get_next_meeting_date(
+        group, after=date.today() - timedelta(days=1)
+    )
     format_type = get_format_for_date(db, group, meeting_date)
 
     log_entry = (
@@ -961,9 +967,15 @@ def get_upcoming_meetings(
     group: Group,
     weeks: int = 4,
 ) -> list[dict]:
-    """Get the next N upcoming meetings with their formats."""
+    """Get the next N upcoming meetings with their formats.
+
+    Uses a 1-day grace period so the most recent meeting stays in the list
+    until the day after it is held.
+    """
     results: list[dict] = []
-    current = get_next_meeting_date(group)
+    current = get_next_meeting_date(
+        group, after=date.today() - timedelta(days=1)
+    )
 
     for _ in range(weeks):
         fmt = get_format_for_date(db, group, current)

--- a/backend/app/services.py
+++ b/backend/app/services.py
@@ -910,9 +910,7 @@ def get_upcoming_meeting_data(db: Session, group: Group) -> dict:
     Uses a 1-day grace period so the meeting remains visible on the landing
     page until the day after it is held.
     """
-    meeting_date = get_next_meeting_date(
-        group, after=date.today() - timedelta(days=1)
-    )
+    meeting_date = get_next_meeting_date(group, after=date.today() - timedelta(days=1))
     format_type = get_format_for_date(db, group, meeting_date)
 
     log_entry = (
@@ -973,9 +971,7 @@ def get_upcoming_meetings(
     until the day after it is held.
     """
     results: list[dict] = []
-    current = get_next_meeting_date(
-        group, after=date.today() - timedelta(days=1)
-    )
+    current = get_next_meeting_date(group, after=date.today() - timedelta(days=1))
 
     for _ in range(weeks):
         fmt = get_format_for_date(db, group, current)

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -846,9 +846,7 @@ class TestUpcomingMeeting:
         assert name is None
         assert total == 3
 
-    def test_grace_period_shows_meeting_day_after(
-        self, db_session: Session
-    ) -> None:
+    def test_grace_period_shows_meeting_day_after(self, db_session: Session) -> None:
         """On the day after a meeting, the landing page still shows it."""
         from unittest.mock import patch
 
@@ -863,9 +861,7 @@ class TestUpcomingMeeting:
             data = get_upcoming_meeting_data(db_session, group)
         assert data["meeting_date"] == date(2025, 1, 5)
 
-    def test_grace_period_advances_two_days_after(
-        self, db_session: Session
-    ) -> None:
+    def test_grace_period_advances_two_days_after(self, db_session: Session) -> None:
         """Two days after a meeting, the landing page shows the next one."""
         from unittest.mock import patch
 
@@ -982,9 +978,7 @@ class TestUpcomingMeetings:
         result = get_upcoming_meetings(db_session, group, weeks=1)
         assert result[0]["is_cancelled"] is True
 
-    def test_grace_period_includes_meeting_day_after(
-        self, db_session: Session
-    ) -> None:
+    def test_grace_period_includes_meeting_day_after(self, db_session: Session) -> None:
         """On the day after a meeting, the lookahead still starts with it."""
         from unittest.mock import patch
 
@@ -999,9 +993,7 @@ class TestUpcomingMeetings:
         assert result[0]["meeting_date"] == date(2025, 1, 5)
         assert result[1]["meeting_date"] == date(2025, 1, 12)
 
-    def test_grace_period_advances_two_days_after(
-        self, db_session: Session
-    ) -> None:
+    def test_grace_period_advances_two_days_after(self, db_session: Session) -> None:
         """Two days after a meeting, the lookahead starts with next meeting."""
         from unittest.mock import patch
 

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -846,6 +846,55 @@ class TestUpcomingMeeting:
         assert name is None
         assert total == 3
 
+    def test_grace_period_shows_meeting_day_after(
+        self, db_session: Session
+    ) -> None:
+        """On the day after a meeting, the landing page still shows it."""
+        from unittest.mock import patch
+
+        # Meeting day is Sunday (6), start_date is Sun Jan 5 2025
+        group = _create_group(db_session, start=date(2025, 1, 5))
+        _create_topics(db_session, group, count=5)
+
+        # On Monday Jan 6 (day after the Jan 5 meeting), should still show Jan 5
+        with patch("app.services.date") as mock_date:
+            mock_date.today.return_value = date(2025, 1, 6)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            data = get_upcoming_meeting_data(db_session, group)
+        assert data["meeting_date"] == date(2025, 1, 5)
+
+    def test_grace_period_advances_two_days_after(
+        self, db_session: Session
+    ) -> None:
+        """Two days after a meeting, the landing page shows the next one."""
+        from unittest.mock import patch
+
+        group = _create_group(db_session, start=date(2025, 1, 5))
+        _create_topics(db_session, group, count=5)
+
+        # On Tuesday Jan 7 (two days after), should show next Sunday Jan 12
+        with patch("app.services.date") as mock_date:
+            mock_date.today.return_value = date(2025, 1, 7)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            data = get_upcoming_meeting_data(db_session, group)
+        assert data["meeting_date"] == date(2025, 1, 12)
+
+    def test_grace_period_shows_meeting_on_meeting_day(
+        self, db_session: Session
+    ) -> None:
+        """On meeting day itself, the landing page shows today's meeting."""
+        from unittest.mock import patch
+
+        group = _create_group(db_session, start=date(2025, 1, 5))
+        _create_topics(db_session, group, count=5)
+
+        # On Sunday Jan 5 (meeting day), should show Jan 5
+        with patch("app.services.date") as mock_date:
+            mock_date.today.return_value = date(2025, 1, 5)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            data = get_upcoming_meeting_data(db_session, group)
+        assert data["meeting_date"] == date(2025, 1, 5)
+
 
 class TestSpeakerBanners:
     """Tests for speaker banner warnings."""
@@ -932,6 +981,40 @@ class TestUpcomingMeetings:
         db_session.flush()
         result = get_upcoming_meetings(db_session, group, weeks=1)
         assert result[0]["is_cancelled"] is True
+
+    def test_grace_period_includes_meeting_day_after(
+        self, db_session: Session
+    ) -> None:
+        """On the day after a meeting, the lookahead still starts with it."""
+        from unittest.mock import patch
+
+        group = _create_group(db_session, start=date(2025, 1, 5))
+        _create_topics(db_session, group, count=3)
+
+        # Monday Jan 6 (day after Sunday Jan 5 meeting)
+        with patch("app.services.date") as mock_date:
+            mock_date.today.return_value = date(2025, 1, 6)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            result = get_upcoming_meetings(db_session, group, weeks=2)
+        assert result[0]["meeting_date"] == date(2025, 1, 5)
+        assert result[1]["meeting_date"] == date(2025, 1, 12)
+
+    def test_grace_period_advances_two_days_after(
+        self, db_session: Session
+    ) -> None:
+        """Two days after a meeting, the lookahead starts with next meeting."""
+        from unittest.mock import patch
+
+        group = _create_group(db_session, start=date(2025, 1, 5))
+        _create_topics(db_session, group, count=3)
+
+        # Tuesday Jan 7 (two days after)
+        with patch("app.services.date") as mock_date:
+            mock_date.today.return_value = date(2025, 1, 7)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            result = get_upcoming_meetings(db_session, group, weeks=2)
+        assert result[0]["meeting_date"] == date(2025, 1, 12)
+        assert result[1]["meeting_date"] == date(2025, 1, 19)
 
 
 class TestExport:


### PR DESCRIPTION
The landing page was advancing to the next meeting at midnight on
meeting day. Users still need to reference the current meeting the
following day. Pass after=today-1 to get_next_meeting_date in the
display functions (get_upcoming_meeting_data, get_upcoming_meetings)
so the most recent meeting stays visible for a 1-day grace period.

Operational endpoints (topic draw, speaker scheduling) are unchanged
and continue to target the true next meeting.

https://claude.ai/code/session_01MRpXiK5bSuwCK4SFwBa4iT