### PR TITLE
fix: display drawn topic on landing page after Draw Topic

### DIFF
--- a/backend/app/routers/topics.py
+++ b/backend/app/routers/topics.py
@@ -9,9 +9,9 @@ from app.models import MeetingLog, Topic, TopicDeckState, User
 from app.schemas import TopicCreate, TopicDrawResponse, TopicResponse
 from app.services import (
     draw_random_topic,
+    get_active_meeting_date,
     get_deck_stats,
     get_format_for_date,
-    get_next_meeting_date,
     log_activity,
     reshuffle_deck,
     undo_topic_draw,
@@ -115,8 +115,8 @@ def draw_topic(
     group = current_user.group
     topic = draw_random_topic(db, group)
 
-    # Store topic_id in meeting log
-    meeting_date = get_next_meeting_date(group)
+    # Store topic_id in meeting log (must match the date shown on the landing page)
+    meeting_date = get_active_meeting_date(group)
     log_entry = (
         db.query(MeetingLog)
         .filter(
@@ -173,7 +173,7 @@ def undo_draw(
 ) -> dict:
     """Undo the last topic draw for the next meeting."""
     group = current_user.group
-    meeting_date = get_next_meeting_date(group)
+    meeting_date = get_active_meeting_date(group)
     try:
         undo_topic_draw(db, group, meeting_date)
     except ValueError as e:

--- a/backend/app/services.py
+++ b/backend/app/services.py
@@ -101,6 +101,18 @@ def get_next_meeting_date(group: Group, after: date | None = None) -> date:
     return after + timedelta(days=days_ahead)
 
 
+def get_active_meeting_date(group: Group) -> date:
+    """Return the meeting date shown on the landing page.
+
+    Applies a 1-day grace period so the current-week meeting remains the
+    "active" meeting until the day after it is held. This must match the
+    date used by :func:`get_upcoming_meeting_data` so mutations from the
+    landing page (e.g. drawing a topic) target the same meeting that is
+    displayed.
+    """
+    return get_next_meeting_date(group, after=date.today() - timedelta(days=1))
+
+
 def count_meetings_since_start(
     db: Session,
     group: Group,
@@ -910,7 +922,7 @@ def get_upcoming_meeting_data(db: Session, group: Group) -> dict:
     Uses a 1-day grace period so the meeting remains visible on the landing
     page until the day after it is held.
     """
-    meeting_date = get_next_meeting_date(group, after=date.today() - timedelta(days=1))
+    meeting_date = get_active_meeting_date(group)
     format_type = get_format_for_date(db, group, meeting_date)
 
     log_entry = (
@@ -971,7 +983,7 @@ def get_upcoming_meetings(
     until the day after it is held.
     """
     results: list[dict] = []
-    current = get_next_meeting_date(group, after=date.today() - timedelta(days=1))
+    current = get_active_meeting_date(group)
 
     for _ in range(weeks):
         fmt = get_format_for_date(db, group, current)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -385,6 +385,48 @@ class TestTopicsEndpoints:
         drawn = next(t for t in topics if t["id"] == drawn_topic_id)
         assert drawn["last_used"] is not None
 
+    def test_drawn_topic_shown_on_upcoming_meeting(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Drawing a topic makes it appear on the landing (upcoming) endpoint.
+
+        Regression: the draw endpoint and /meetings/upcoming must agree on
+        which meeting_date is "current" — otherwise the drawn topic is
+        written to one row while the landing page reads another, and the
+        topic silently fails to display.
+        """
+        # Only meaningful when the upcoming meeting's format is Topic; skip
+        # otherwise so the test is robust across calendar positions.
+        upcoming = client.get("/meetings/upcoming", headers=auth_headers).json()
+        if upcoming["format_type"] != "Topic":
+            return
+
+        draw_response = client.post("/topics/draw", headers=auth_headers)
+        assert draw_response.status_code == 200
+        drawn_name = draw_response.json()["topic"]["name"]
+
+        refreshed = client.get("/meetings/upcoming", headers=auth_headers).json()
+        assert refreshed["topic_name"] == drawn_name
+
+    def test_undo_clears_topic_on_upcoming_meeting(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Undoing a draw removes the topic from the landing endpoint."""
+        upcoming = client.get("/meetings/upcoming", headers=auth_headers).json()
+        if upcoming["format_type"] != "Topic":
+            return
+
+        client.post("/topics/draw", headers=auth_headers)
+        undo = client.post("/topics/undo", headers=auth_headers)
+        assert undo.status_code == 200
+
+        refreshed = client.get("/meetings/upcoming", headers=auth_headers).json()
+        assert refreshed["topic_name"] is None
+
 
 class TestBookEndpoints:
     """Tests for book/reading plan endpoints."""

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -25,6 +25,7 @@ from app.services import (
     finalize_current_assignment,
     generate_csv_export,
     generate_printable_export,
+    get_active_meeting_date,
     get_book_position,
     get_current_draft_assignment,
     get_deck_stats,
@@ -739,7 +740,7 @@ class TestUpcomingMeeting:
     ) -> None:
         group = _create_group(db_session, start=date(2025, 1, 5))
         _create_topics(db_session, group, count=3)
-        next_date = get_next_meeting_date(group)
+        next_date = get_active_meeting_date(group)
         db_session.add(
             MeetingLog(
                 group_id=group.id,
@@ -965,7 +966,7 @@ class TestUpcomingMeetings:
     def test_cancelled_meeting_shown(self, db_session: Session) -> None:
         group = _create_group(db_session)
         _create_topics(db_session, group, count=3)
-        next_date = get_next_meeting_date(group)
+        next_date = get_active_meeting_date(group)
         db_session.add(
             MeetingLog(
                 group_id=group.id,


### PR DESCRIPTION
The /topics/draw endpoint was writing topic_id to the meeting row at
get_next_meeting_date(group) (today or later), but /meetings/upcoming
reads the row at get_next_meeting_date(group, after=today-1) due to the
1-day post-meeting grace period added in #96. On the day after a
meeting the two dates diverge by a week, so the drawn topic is saved
to next week's row while the landing page keeps showing the previous
meeting's row with topic_name=None.

Introduce get_active_meeting_date() as the single source of truth for
"which meeting is current on the landing page," and use it from both
the read path (get_upcoming_meeting_data, get_upcoming_meetings) and
the mutation paths (/topics/draw, /topics/undo) so they always target
the same row. Also fix two date-sensitive tests that relied on the
pre-#96 behavior.