### PR TITLE
docs: add README, LICENSE, CONTRIBUTING, and CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,118 @@
+# Code of Conduct
+
+## Our Commitment
+
+rd-log is a tool built to serve Recovery Dharma sanghas, and its community
+space — issues, pull requests, reviews, discussions — is held in the spirit
+of the tradition it serves. We commit to making participation in this
+project a safe, welcoming, and supportive experience for everyone, regardless
+of age, body, disability, ethnicity, gender identity and expression, level of
+experience, nationality, personal appearance, race, religion, recovery
+status, sexual identity or orientation, or socioeconomic background.
+
+## Our Values
+
+This project draws its community standards from the core values of Recovery
+Dharma: **mindfulness, compassion, forgiveness, and generosity**, together
+with the wise speech guidance of the Eightfold Path.
+
+Concretely, we aspire to communication that is:
+
+- **True** — grounded in fact, not assumption
+- **Kind** — chosen with care for the person on the other side of the screen
+- **Useful** — moving the work, the person, or the community forward
+- **Timely** — offered when it can actually help
+
+And we practice:
+
+- **Mindfulness** — pausing before reacting; noticing our tone in reviews
+- **Compassion** — assuming good faith; remembering that every contributor
+  is a person
+- **Forgiveness** — letting go of small frictions; not keeping score
+- **Generosity** — reviewing patiently, teaching gladly, and celebrating
+  others' contributions
+
+## Encouraged Behavior
+
+- Welcoming and inclusive language
+- Respect for differing viewpoints and experiences
+- Graceful acceptance of constructive feedback
+- Focus on what is best for the community and the sanghas we serve
+- Empathy and patience toward new contributors
+- Holding space for people in recovery without pressuring disclosure
+
+## Unacceptable Behavior
+
+- Harassment, discriminatory jokes, or personal attacks
+- Sexualized language or imagery, and unwelcome sexual attention
+- Publishing others' private information (sangha membership, recovery
+  status, legal name, contact info, etc.) without explicit permission
+- Deliberately misgendering or using a contributor's prior name
+- Sustained disruption of discussions or reviews
+- Trolling, dismissiveness, or bad-faith argumentation
+- Using project channels to evangelize for, or against, any particular
+  recovery path, religion, or political position
+- Any conduct that would reasonably be considered inappropriate in a
+  Recovery Dharma meeting space
+
+## Recovery-Community Considerations
+
+Because this project serves a recovery community, a few additional norms
+apply:
+
+- **Anonymity is respected.** Do not out anyone as a member of a sangha, as
+  being in recovery, or as having any particular history.
+- **No practice policing.** Recovery Dharma is one path among many. Do not
+  disparage other recovery programs or pressure anyone about their own
+  practice.
+- **No unsolicited advice about someone's recovery.** Keep discussions in
+  this project focused on the software.
+- **Never include real users' data** — names, notes, meeting content — in
+  issues, PRs, screenshots, or test fixtures.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — the GitHub
+repository, issues, pull requests, discussions, code review threads, and
+any other space where people are representing the project or interacting
+with its community. It also applies when representing the project in public
+spaces, such as speaking about rd-log at a Recovery Dharma meeting or on
+social media.
+
+It does **not** attempt to govern anyone's behavior inside a Recovery
+Dharma meeting itself — that is rightly the domain of each sangha and
+Recovery Dharma Global.
+
+## Enforcement
+
+If you experience or witness behavior that violates this Code of Conduct,
+please report it to the project maintainer:
+
+- **Geoff Gallinger** — via a direct message on GitHub, or by email if you
+  already have the address.
+
+All reports will be handled with discretion and confidentiality. You will
+not be asked to disclose more than you are comfortable disclosing.
+
+The maintainer will:
+
+1. Acknowledge the report, usually within a few days.
+2. Review the situation with care and without rushing to judgment.
+3. Decide on a response, which may include a private conversation, a
+   public clarification, a temporary cooldown, or — in serious or repeated
+   cases — removal from the project's community spaces.
+
+Maintainers who fail to uphold this Code of Conduct in good faith may face
+the same consequences as any other community member.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/),
+and grounded in the values and traditions of
+[Recovery Dharma](https://recoverydharma.org/). It is not an official
+document of Recovery Dharma Global.
+
+---
+
+_May all beings be free from suffering. May all beings find peace._

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,166 @@
+# Contributing to rd-log
+
+Thank you for considering a contribution. rd-log is a small tool built to
+support Recovery Dharma sanghas, and it gets better every time someone from
+the community shares their time, code, or feedback.
+
+> **Not affiliated with Recovery Dharma Global.** rd-log is an independent,
+> community-built tool. It is not operated, endorsed, maintained, or
+> reviewed by Recovery Dharma Global (RDG), the RDG Board of Directors, or
+> any local sangha. "Recovery Dharma" is referenced only to describe the
+> tradition this software is built to serve.
+
+Before anything else, please read and agree to our
+[Code of Conduct](./CODE_OF_CONDUCT.md). This project is offered in the
+spirit of the Recovery Dharma tradition, and we ask contributors to carry
+that spirit — mindfulness, compassion, forgiveness, and generosity — into
+every issue, pull request, and review.
+
+## Ways to Contribute
+
+You don't have to write code to help.
+
+- **Report a bug.** If something is broken or confusing, open an issue
+  describing what you expected and what happened. Screenshots help.
+- **Suggest a feature.** Especially welcome: ideas that come from your
+  sangha's actual practice. Describe the meeting problem first, the feature
+  second.
+- **Improve the docs.** READMEs, inline comments, and this file can always
+  be clearer. Small doc PRs are very welcome.
+- **Write code.** Bug fixes, features, tests, refactors — all welcome.
+- **Help other contributors.** Reviewing PRs, answering questions in issues,
+  and triaging reports is as valuable as writing code.
+- **Practice Dana directly.** If rd-log helps your sangha, the most
+  meaningful thank-you is to [support Recovery Dharma
+  Global](https://recoverydharma.org/) or your local sangha — not this
+  project.
+
+## A Note on Sensitive Material
+
+This project serves a recovery community. Please do not include real
+sangha members' names, recovery details, or any identifying information in
+issues, PRs, commits, screenshots, or test fixtures. If you are reporting a
+bug that involves real data, scrub it first.
+
+If you find a security issue (especially anything that could expose user
+data), please **do not** open a public issue. Email Geoff directly or use
+GitHub's private vulnerability reporting on the repository.
+
+## Development Workflow
+
+rd-log follows a **Stay Green** workflow: every commit should leave the tree
+green. The full engineering standards are documented in
+[`CLAUDE.md`](./CLAUDE.md); the short version is below.
+
+### 1. Fork and branch
+
+```bash
+git clone https://github.com/<you>/recovery-dharma-log.git
+cd recovery-dharma-log
+git checkout -b your-feature-branch
+```
+
+Use descriptive branch names (`fix/rotation-off-by-one`,
+`feat/csv-export`, etc.).
+
+### 2. Set up your environment
+
+See [`README.md`](./README.md) and the subproject READMEs in
+[`frontend/`](./frontend/README.md) and [`backend/`](./backend/README.md).
+
+Install pre-commit hooks — this catches most issues before CI does:
+
+```bash
+pre-commit install
+```
+
+### 3. Make your change
+
+A few guidelines drawn from the project's
+[`CLAUDE.md`](./CLAUDE.md):
+
+- **Use the project scripts**, not the underlying tools directly.
+  `./scripts/check-all.sh` runs everything; individual scripts exist for
+  each step.
+- **No shortcuts.** Don't disable tests, don't lower thresholds, don't
+  `--no-verify` commits. If a check is wrong, fix the check properly.
+- **DRY.** Link to canonical docs instead of copying content between files.
+- **Operate from the project root.** Don't `cd` into subdirectories in
+  scripts or commands — CI runs from the root.
+
+### 4. Test
+
+All changes need tests. The standards are:
+
+- Line coverage **≥ 90%**
+- Branch coverage **≥ 85%**
+- Mutation score **≥ 80%** (where Stryker/mutmut is applicable)
+- Cyclomatic complexity **≤ 10** per function
+
+Run the full suite before pushing:
+
+```bash
+./scripts/check-all.sh
+```
+
+Only push when this exits `0`.
+
+### 5. Commit
+
+We use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat(meetings): add attendance-count override
+fix(rotation): don't skip speakers after manual override
+docs(readme): clarify self-hosting instructions
+```
+
+Write commit messages that explain **why**, not just **what**.
+
+### 6. Open a pull request
+
+- Fill out the PR template.
+- Describe the change, the motivation, and how you tested it.
+- Link any related issues.
+- Ensure CI is green **before** requesting review.
+
+PRs with failing CI will not be reviewed until they are green — this is the
+Stay Green policy, and it applies to everyone including maintainers.
+
+### 7. Review
+
+- Expect feedback. It is not personal; it is practice.
+- Address all comments. If you disagree, say so and discuss — silent dismissal
+  isn't the way.
+- Maintainers merge when CI is green, reviews are LGTM, and the contributor
+  is satisfied.
+
+## Style
+
+- **TypeScript**: strict mode, no `any` without a written justification.
+- **Python**: typed, `ruff`-clean, `mypy`-clean.
+- **Formatting**: Prettier (frontend), Black + isort (backend). Run
+  `./scripts/format.sh` before committing.
+- **Comments**: explain *why*, not *what*. If the code needs a comment to
+  explain what it's doing, consider renaming something instead.
+
+## What Won't Be Merged
+
+To keep the project healthy and aligned with its purpose, a few kinds of
+change won't be accepted:
+
+- Features that collect, sell, or expose sangha members' personal data.
+- Ads, tracking, or monetization of the hosted instance.
+- Anything that makes the app harder for a sangha to self-host for free.
+- Changes that break the Stay Green workflow or silence quality checks
+  without a documented, justified reason.
+
+## License of Contributions
+
+By submitting a contribution, you agree that your contribution is released
+under the same [MIT License](./LICENSE) as the rest of the project.
+
+## Thank You
+
+Every issue opened, every test added, every typo fixed is Dana to the next
+sangha that uses this tool. Thank you for practicing with us.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,40 @@
+MIT License
+
+Copyright (c) 2026 Geoff Gallinger and rd-log contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## A Note on Intent
+
+This project is offered in the spirit of **Dana** (generosity) — the first of
+the Buddhist paramitas and a foundational practice in the Recovery Dharma
+tradition. The hosted instance maintained by Geoff Gallinger is offered freely
+as Dana to the Recovery Dharma sangha, in gratitude for the merit received
+from the community and its practice. The source code is released under the
+MIT License so that any sangha, meeting, or individual may freely use, fork,
+modify, self-host, and share it.
+
+This software is **not** an official project of Recovery Dharma Global
+(RDG). It is not operated, endorsed, sponsored, reviewed, or maintained by
+RDG, its Board of Directors, or any local sangha, and no such relationship
+is claimed or implied. It is an independent, community-built tool created
+to support sanghas in their practice. "Recovery Dharma" is referenced here
+solely to describe the tradition this tool is built to serve.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,146 @@
+# rd-log
+
+A free, open-source meeting log and sangha companion for
+[Recovery Dharma](https://recoverydharma.org/) groups.
+
+> _"Recovery Dharma is a peer-led movement and community that is unified by
+> our trust in the potential of each of us to recover and find freedom from
+> the suffering of addiction."_
+> — [Recovery Dharma](https://recoverydharma.org/about/)
+
+## About
+
+**rd-log** helps Recovery Dharma sanghas track the simple, practical things
+that keep a meeting healthy: attendance, rotating speakers and topics, where
+the group is in the Recovery Dharma book, meeting activity, and group
+settings. It is designed to be used by the person opening the meeting, shared
+by the whole sangha, and easy enough that it stays out of the way of the
+practice itself.
+
+> **Not affiliated with Recovery Dharma Global.** This project is not
+> operated, endorsed, sponsored, reviewed, or maintained by Recovery Dharma
+> Global (RDG), its Board of Directors, or any local sangha. It is an
+> independent, community-built tool offered by a single practitioner in the
+> spirit of Dana to any sangha that finds it useful. "Recovery Dharma" is
+> referenced here only to describe the tradition this tool is built to
+> serve; no official relationship is claimed or implied.
+
+## Dana — An Offering in Gratitude
+
+The hosted instance of rd-log is maintained and paid for by
+**Geoff Gallinger** as his personal **Dana** (generosity) to the Recovery
+Dharma community, in gratitude for the merit he has received from the
+practice and the sangha. Using the hosted instance is and will remain free.
+
+Dana — the first of the paramitas — is the practice of giving freely without
+expectation of return. In Recovery Dharma, the tradition of passing the dana
+basket at meetings sustains the sangha; this project is offered in that same
+spirit. If you wish to practice dana in return, the most meaningful way is to
+[support Recovery Dharma Global](https://recoverydharma.org/) or your local
+sangha directly — not this project.
+
+## Free and Open Source
+
+rd-log is released under the [MIT License](./LICENSE). You are free to:
+
+- Use the hosted instance at no cost
+- Self-host your own instance for your sangha
+- Fork, modify, and adapt the code for your community's needs
+- Contribute improvements back so other sanghas benefit
+
+Openness suits Recovery Dharma's values. The Dharma is freely shared; so is
+this code.
+
+## Features
+
+- **Meeting logs** — record attendance, speakers, topics, and notes
+- **Book tracking** — keep track of where your group is in the Recovery
+  Dharma book across cycles and chapters
+- **Speaker and topic rotation** — simple rotation helpers so no one gets
+  overlooked and no topic gets repeated too soon
+- **Group setup and settings** — configure the meeting format, invite
+  members with a short code, and override rotations when needed
+- **Activity view** — a read-only feed of what the sangha has been up to
+- **Data export** — your sangha's data belongs to your sangha; export it any
+  time
+
+## Tech Stack
+
+- **Frontend**: React 19 + TypeScript + Vite
+  ([`frontend/`](./frontend/README.md))
+- **Backend**: FastAPI + SQLAlchemy (Python)
+  ([`backend/`](./backend/README.md))
+- **Database**: SQLite by default; PostgreSQL supported
+- **Hosting**: Railway (for the maintained instance); anywhere Docker runs
+  otherwise
+
+## Getting Started
+
+### Using the Hosted Instance
+
+If your sangha just wants to use rd-log, you do not need to install anything.
+Ask Geoff or an existing group admin for an invite code, or set up a new
+group from the landing page.
+
+### Running Locally
+
+You will need Python 3.11+, Node.js 20+, and `pre-commit`.
+
+```bash
+# Clone
+git clone https://github.com/geoffe-ga/recovery-dharma-log.git
+cd recovery-dharma-log
+
+# Configure
+cp .env.example .env
+# then edit .env — at minimum set RD_LOG_SECRET_KEY
+
+# Backend
+./run-backend.sh
+
+# Frontend (in another terminal)
+./run-frontend.sh
+```
+
+The frontend will be served at <http://localhost:5173> and the API at
+<http://localhost:8000>. See the subproject READMEs for details:
+
+- [`frontend/README.md`](./frontend/README.md)
+- [`backend/README.md`](./backend/README.md)
+
+### Self-Hosting for Your Sangha
+
+rd-log ships with a `Dockerfile` and a `railway.json` so any sangha that
+wants its own instance can stand one up. Set the environment variables
+described in [`.env.example`](./.env.example) — especially a strong
+`RD_LOG_SECRET_KEY` — and deploy.
+
+## Contributing
+
+Contributions are welcome from anyone, sangha member or not. See
+[CONTRIBUTING.md](./CONTRIBUTING.md) for how to get involved, how we work
+together, and the quality expectations for the codebase.
+
+All participants are expected to follow our
+[Code of Conduct](./CODE_OF_CONDUCT.md), which is grounded in the Recovery
+Dharma values of mindfulness, compassion, forgiveness, and generosity.
+
+## Project Status
+
+rd-log is actively maintained by Geoff Gallinger with contributions from the
+community. It is offered as-is under the terms of the MIT License; there is
+no warranty and no guaranteed support. That said, issues and pull requests
+are read and appreciated.
+
+## License
+
+[MIT](./LICENSE). Copyright © 2026 Geoff Gallinger and rd-log contributors.
+
+## Acknowledgements
+
+- The **Recovery Dharma** community, whose book, meetings, and sangha made
+  this project possible and worthwhile.
+- Every sangha member, past and present, whose practice is the merit this
+  Dana is offered in gratitude for.
+
+_May all beings be free from suffering. May all beings find peace._


### PR DESCRIPTION
Add project-root documentation positioning rd-log as a free, open-source
tool for Recovery Dharma sanghas, offered as Dana by Geoff Gallinger.

- LICENSE: MIT, with a note that the hosted instance is offered as Dana
  and an explicit disclaimer of any affiliation with Recovery Dharma
  Global.
- README.md: overview, features, self-hosting, and non-affiliation notice.
- CONTRIBUTING.md: Stay Green workflow, quality standards, and guidance
  on handling sensitive sangha data.
- CODE_OF_CONDUCT.md: Contributor Covenant adapted to the values of the
  Recovery Dharma tradition (mindfulness, compassion, forgiveness,
  generosity), with recovery-community-specific norms around anonymity
  and practice-policing.