### PR TITLE
fix(css): make speaker name input fill available width on mobile

### DIFF
--- a/frontend/src/styles/rd-theme.css
+++ b/frontend/src/styles/rd-theme.css
@@ -1167,14 +1167,17 @@ button.rd-reading-history__row {
   display: flex;
   gap: var(--rd-space-xs);
   align-items: flex-end;
+  flex-wrap: wrap;
 }
 
 .rd-speaker-schedule__form input {
+  flex: 1 1 160px;
+  min-width: 0;
   margin-bottom: 0;
-  max-width: 160px;
 }
 
 .rd-speaker-schedule__form button {
+  flex: none;
   margin-bottom: 0;
   white-space: nowrap;
 }

--- a/frontend/tests/Landing.test.tsx
+++ b/frontend/tests/Landing.test.tsx
@@ -939,6 +939,24 @@ describe("Landing", () => {
       });
       expect(screen.queryByText("Speaker Schedule")).not.toBeInTheDocument();
     });
+
+    it("renders assignment form with mobile-friendly flex class", async () => {
+      const user = userEvent.setup();
+      getUpcomingMeeting.mockResolvedValue(baseMeeting);
+      renderLanding();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Assign Speaker" }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: "Assign Speaker" }));
+
+      const input = screen.getByPlaceholderText("Speaker name");
+      const form = input.closest("form");
+      expect(form).toHaveClass("rd-speaker-schedule__form");
+    });
   });
 
   describe("format overrides", () => {


### PR DESCRIPTION
The speaker name text input in the Speaker Schedule section was squeezed
to ~2 characters wide on mobile because it had a fixed max-width: 160px
while the Save/Cancel buttons took fixed space in the flex row.

Apply the same pattern used in PR #89 for the topic input: give the
input flex: 1 1 160px with min-width: 0 so it takes available space,
and flex: none on the buttons so they keep their natural size.

Closes #91

https://claude.ai/code/session_01CAZze7RRkHRUy3nzh2KLs6