### PR TITLE
fix(docker): chown SQLite volume before dropping to uid 1001

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -71,11 +71,18 @@ jobs:
         run: |
           set -euo pipefail
           echo "::group::Assert runtime runs as uid 1001"
-          uid=$(docker run --rm --entrypoint id rd-log:security-scan -u)
+          # Run `id -u` *through* the image's ENTRYPOINT (no --entrypoint
+          # override) so we observe the uid the main process sees after
+          # docker-entrypoint.sh drops privileges from root to `app`.
+          # That is the uid the real Python server runs with in production.
+          uid=$(docker run --rm rd-log:security-scan id -u)
           test "$uid" = "1001" || { echo "Runtime UID is $uid, expected 1001"; exit 1; }
           echo "::endgroup::"
 
           echo "::group::Assert pip is not present in runtime image"
+          # Bypass the entrypoint here: we want to test the image's
+          # filesystem for pip regardless of which user the entrypoint
+          # would drop to.
           if docker run --rm --entrypoint sh rd-log:security-scan -c 'command -v pip'; then
             echo "pip is present in runtime image — remove it or use an isolated virtualenv"
             exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,16 @@ FROM python:3.12-slim AS runtime
 RUN groupadd --system --gid 1001 app \
  && useradd  --system --uid 1001 --gid app --home-dir /app --shell /sbin/nologin app
 
+# `gosu` is a tiny (<2MB) setuid-aware wrapper that drops privileges from
+# root to the target user before exec'ing the command. The init script
+# (`docker-entrypoint.sh`) uses it so that the container can briefly run as
+# root to chown Railway's root-owned bind-mounted volume, then hand off to
+# the hardened `app` user for the actual application process.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends gosu \
+ && rm -rf /var/lib/apt/lists/* \
+ && gosu nobody true
+
 WORKDIR /app
 
 # Copy the virtualenv from the build stage, then strip pip from both the
@@ -64,10 +74,23 @@ ENV PATH=/opt/venv/bin:$PATH \
 COPY --chown=app:app backend/app/ ./app/
 COPY --from=frontend-build --chown=app:app /app/frontend/dist ./static/dist
 
-# Drop privileges.
-USER app:app
+# Init script: when launched as root (the Railway/default case) it chowns
+# the SQLite database directory so the unprivileged app user can write to
+# it, then drops to `app:app` via gosu and exec's CMD. When the container
+# is run with a non-root uid enforced by the orchestrator, the script
+# skips the chown step and exec's CMD directly, so the image remains
+# usable in environments that pin the uid themselves.
+COPY --chmod=0755 backend/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 EXPOSE 8000
+
+# Start as root so the entrypoint can adjust volume ownership. The
+# entrypoint immediately drops to uid 1001 via `gosu` before exec'ing the
+# CMD, so the long-running Python process still satisfies the hardening
+# requirement from Issue #15 (verified by the security workflow, which
+# runs `id -u` *through* the entrypoint to observe the effective main-
+# process uid).
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
 # Exec form so the Python process is PID 1 and receives SIGTERM directly from
 # the container runtime (Railway, docker, kubelet). ``app.entrypoint`` reads

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# Container init script.
+#
+# Railway (and many other bind-mounted volume providers) mount persistent
+# volumes with root ownership. The application image runs as the
+# unprivileged `app` user (uid 1001) per the container-hardening work in
+# Issue #15, so it cannot write to a root-owned mount. When that mount
+# holds the SQLite database, startup migrations fail with
+# `sqlite3.OperationalError: attempt to write a readonly database`.
+#
+# This script runs as PID 1 when the container starts. If it is invoked as
+# root, it ensures the SQLite database directory exists and is owned by
+# `app:app`, then drops privileges via `gosu` before exec'ing the real
+# command. If it is already running as a non-root user (e.g. when an
+# orchestrator enforces `runAsUser` itself), it just exec's the command
+# unchanged — the process UID remains 1001, preserving the hardening
+# guarantee.
+
+set -eu
+
+APP_USER="app"
+
+# Parse the SQLAlchemy SQLite URL in RD_LOG_DATABASE_URL and echo the
+# filesystem path of the database file. Prints nothing (and exits 0) for
+# non-SQLite URLs or unset values.
+#
+# SQLAlchemy URL convention:
+#   sqlite:///relative/path.db   (three slashes -> path is relative to CWD)
+#   sqlite:////abs/path.db       (four  slashes -> path is absolute)
+resolve_sqlite_path() {
+    url="${RD_LOG_DATABASE_URL:-}"
+    case "$url" in
+        sqlite:*) ;;
+        *) return 0 ;;
+    esac
+
+    # Strip the "sqlite://" scheme prefix, then drop exactly one leading
+    # slash. Whatever remains is the raw SQLAlchemy path: relative paths
+    # have no leading slash, absolute paths still start with '/'.
+    rest="${url#sqlite://}"
+    rest="${rest#/}"
+
+    case "$rest" in
+        /*) printf '%s\n' "$rest" ;;
+        *)  printf '%s/%s\n' "$(pwd)" "$rest" ;;
+    esac
+}
+
+prepare_sqlite_dir() {
+    path="$(resolve_sqlite_path)"
+    [ -n "$path" ] || return 0
+
+    dir="$(dirname "$path")"
+    mkdir -p "$dir"
+
+    # Chown the directory (and, if it already exists, the db file) so the
+    # unprivileged app user can open a write transaction. `|| true` keeps
+    # startup resilient if the filesystem disallows chown (e.g. a read-only
+    # bind mount used deliberately by the operator).
+    chown -R "${APP_USER}:${APP_USER}" "$dir" 2>/dev/null || true
+    if [ -f "$path" ]; then
+        chown "${APP_USER}:${APP_USER}" "$path" 2>/dev/null || true
+    fi
+}
+
+if [ "$(id -u)" = "0" ]; then
+    prepare_sqlite_dir
+    exec gosu "${APP_USER}:${APP_USER}" "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
The hardening in #101 set `USER app:app` (uid 1001) in the runtime image,
but Railway bind-mounts persistent volumes with root ownership. The app
user can read the existing SQLite DB (so `create_all` and `inspect`
succeed) but cannot open a write transaction, so the `_run_data_migrations`
UPDATE crashes startup with:

    sqlite3.OperationalError: attempt to write a readonly database

Add a `docker-entrypoint.sh` that parses `RD_LOG_DATABASE_URL`, ensures
the SQLite parent directory exists, chowns it to `app:app`, then drops
privileges to `app:app` via `gosu` and exec's CMD. The long-running
Python process still runs as uid 1001, so the Issue #15 hardening
guarantee is preserved.

Update the security workflow's uid assertion to invoke `id -u` *through*
the entrypoint (instead of `--entrypoint id -u`) so it observes the
effective main-process uid rather than the pre-drop root uid.